### PR TITLE
Drop obsolete link-check excludes

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,15 +30,9 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          # Releases and crates.io 404 until the first release is published, and
-          # the Pages site 404s until the docs workflow has run once. Drop those
-          # excludes after the first release.
           args: >-
             --no-progress
             --max-concurrency 8
-            --exclude '^https://github\.com/holistic-ai/surface/releases'
-            --exclude '^https://crates\.io/crates/surface-cli'
-            --exclude '^https://holistic-ai\.github\.io/surface'
             --exclude-path target
             --exclude-path site
             './**/*.md'


### PR DESCRIPTION
## What changed

- remove the obsolete exclusions for the Releases page, crates.io package page, and documentation site
- remove the stale pre-release comment associated with those exclusions

## Why

The v0.1.0 release, crates.io package, and Pages site are now published. Keeping
these exclusions prevents the scheduled workflow from reporting broken links in
the project's most frequently read Markdown files.

## Validation

- parsed `.github/workflows/links.yml` as YAML
- ran `git diff --check`
- confirmed the Releases and Pages URLs resolve
- confirmed `surface-cli` 0.1.0 through the crates.io API

Closes #35
