### PR TITLE
ci: drop obsolete Releases/Pages link-check excludes

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,15 +30,14 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          # Releases and crates.io 404 until the first release is published, and
-          # the Pages site 404s until the docs workflow has run once. Drop those
-          # excludes after the first release.
+          # v0.1.0 shipped 2026-07-28, so the Releases and Pages links now
+          # resolve. crates.io still 404s: the release didn't include a
+          # `cargo publish`, so `surface-cli` isn't live there yet. Drop that
+          # exclude once the crate is actually published.
           args: >-
             --no-progress
             --max-concurrency 8
-            --exclude '^https://github\.com/holistic-ai/surface/releases'
             --exclude '^https://crates\.io/crates/surface-cli'
-            --exclude '^https://holistic-ai\.github\.io/surface'
             --exclude-path target
             --exclude-path site
             './**/*.md'


### PR DESCRIPTION
## Issue
#35 — the weekly link-check workflow excludes Releases, crates.io, and Pages URLs with a comment saying to drop them after the first release. v0.1.0 shipped 2026-07-28.

## Change
Removes the `Releases` and `Pages` excludes, since both now resolve.

**Kept the `crates.io` exclude**, unlike the issue's literal checklist: verified the v0.1.0 release didn't include a `cargo publish` step, so `crates.io/crates/surface-cli` still 404s (checked with a browser user agent — a plain `curl` gets a 403 from Cloudflare that's misleading here). Removing it now would just turn the weekly check red on something no one can act on. Updated the inline comment to explain and left a pointer to drop it once the crate is actually published.

## Testing
- `curl` (with a browser UA) against all three previously-excluded URLs:
  - Releases: 200
  - Pages: 301 (valid redirect)
  - crates.io: 404 (still excluded)
- Confirmed the crate name (`surface-cli`) against `Cargo.toml` and the README badge/install instructions.
- Don't have a Rust toolchain in this environment to run `lychee` itself; the diff is a 4-line YAML change with no structural edits, reviewed by hand.

Fixes #35