### PR TITLE
feat(ui): name the tools behind each row in the Projects view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ publishing empty notes.
 
 ## [Unreleased]
 
+### Added
+
+- **The Projects view names the tools behind each repository.** Each project
+  row ends in a `TOOLS` column listing the tools whose sessions ran there,
+  behind the same series texture the usage chart keys that tool by — so two
+  rows like `HAI Neo` and `owner/hai-neo` finally read as "the Codex checkout"
+  and "the Claude Code one". It replaces the share bar, which repeated TOKENS
+  as decoration.
+
 ## [0.1.0] - 2026-07-28
 
 First release.

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -286,7 +286,7 @@ walks projects and the chart follows.
 | **MESSAGES** | Records counted, after deduplication |
 | **COST** | `$12.40`, or `≥$12.40` when unpriced models sit under it |
 | **LAST USED** | Last day this project saw any usage |
-| | Share of the busiest project's tokens, as a bar |
+| **TOOLS** | The tools whose sessions ran here, each behind its series texture |
 
 ```
 ┌ acme/platform · 30 buckets · 568M total · peak 67.4M · [w] regroup ──────────┐
@@ -299,12 +299,12 @@ walks projects and the chart follows.
 │       █ claude_code  ▓ codex  ▒ ollama  ░ opencode                           │
 └──────────────────────────────────────────────────────────────────────────────┘
 ┌ 16 projects over 30 days · ▲ 1 ≥ a floor ───┐┌ 72 sessions in this project ══╗
-│PROJECT              TOKENS     COST         ││● invoice rounding bug   $56.17│
+│PROJECT         TOKENS COST     TOOLS        ││● invoice rounding bug   $56.17│
 │                                             ││  claude_code · 2026-07-28 · 3…│
-│acme/platform        568M       $628.71  ████││● flaky checkout test    $32.80│
-│acme/webapp          200M       $268.07  ██  ││  opencode · 2026-07-27 · 34.8…│
-│acme/mobile-app      123M       $183.33  █   ││● cache keys collide u…  $30.22│
-│(unattributed)       125M       $150.56  █   ││  claude_code · 2026-07-26 · 1…│
+│acme/platform   568M   $628.71  █ claude_cod…││● flaky checkout test    $32.80│
+│acme/webapp     200M   $268.07  ░ opencode   ││  opencode · 2026-07-27 · 34.8…│
+│acme/mobile-app 123M   $183.33  ▓ codex      ││● cache keys collide u…  $30.22│
+│(unattributed)  125M   $150.56  █ claude_cod…││  claude_code · 2026-07-26 · 1…│
 └─────────────────────────────────────────────┘╚═══════════════════════════════╝
 ```
 
@@ -394,9 +394,9 @@ per-series totals. Two properties they hold to:
   Ink and Paper, the same ramp as this site — so tools are told apart by texture
   rather than hue: `█ ▓ ▒ ░`, heaviest at the bottom of a stack. Each one's grey
   compensates its own density, because `░` inks a quarter of its cell and in the
-  same grey as `█` would read a quarter as strongly. Only the Projects chart and
-  the sessions pane use textures now; every chart with a palette is keyed by
-  model.
+  same grey as `█` would read a quarter as strongly. Only the Projects chart,
+  its table's TOOLS column and the sessions pane use textures now; every chart
+  with a palette is keyed by model.
 
     Models get real colour, from the brand's blue ramp, because a model is the one
     thing a reader needs to trace between a chart and a table. Six are named and

--- a/src/app.rs
+++ b/src/app.rs
@@ -167,6 +167,11 @@ pub struct RepoRow {
     /// Last day this repository saw any usage, `YYYY-MM-DD`. Empty only if the
     /// row somehow has no days under it, which the builder cannot produce.
     pub last_day: String,
+    /// The tools whose sessions ran in this repository, in stable order.
+    /// Derived from session metadata: the projects map itself has no tool
+    /// axis, and two slugs like `HAI Neo` and `owner/hai-neo` are otherwise
+    /// indistinguishable as "the Codex one" and "the Claude Code one".
+    pub tools: Vec<String>,
 }
 
 /// One session's usage over the window, for the breakdown under a project.
@@ -408,6 +413,21 @@ impl App {
             })
             .collect();
 
+        // Which tools ran in each repository, from the session metadata the
+        // ledger already keeps. Slots follow `self.series`, so a repo's tools
+        // list in the same order (and texture) as the usage chart's legend.
+        let mut tools_by_repo: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for tool in &self.series {
+            for meta in self.ledger().session_meta.values() {
+                if meta.tool == *tool {
+                    let entry = tools_by_repo.entry(meta.repo.clone()).or_default();
+                    if !entry.contains(tool) {
+                        entry.push(tool.clone());
+                    }
+                }
+            }
+        }
+
         let mut repos: Vec<RepoRow> = self
             .ledger()
             .by_project()
@@ -426,6 +446,7 @@ impl App {
                 }
                 RepoRow {
                     last_day: last_day.get(&repo).cloned().unwrap_or_default(),
+                    tools: tools_by_repo.remove(&repo).unwrap_or_default(),
                     repo,
                     tokens: tokens.total(),
                     messages: tokens.messages,

--- a/src/app.rs
+++ b/src/app.rs
@@ -167,10 +167,14 @@ pub struct RepoRow {
     /// Last day this repository saw any usage, `YYYY-MM-DD`. Empty only if the
     /// row somehow has no days under it, which the builder cannot produce.
     pub last_day: String,
-    /// The tools whose sessions ran in this repository, in stable order.
-    /// Derived from session metadata: the projects map itself has no tool
-    /// axis, and two slugs like `HAI Neo` and `owner/hai-neo` are otherwise
+    /// The tools whose sessions ran in this repository, in series order.
+    /// Two slugs like `HAI Neo` and `owner/hai-neo` are otherwise
     /// indistinguishable as "the Codex one" and "the Claude Code one".
+    ///
+    /// From [`Ledger::tools_by_repo`], so it answers "which tools ran here":
+    /// session attribution is first-wins, and a session that moved between
+    /// checkouts marks only the repository it started in — which is also the
+    /// one way this can be empty.
     pub tools: Vec<String>,
 }
 
@@ -413,19 +417,21 @@ impl App {
             })
             .collect();
 
-        // Which tools ran in each repository, from the session metadata the
-        // ledger already keeps. Slots follow `self.series`, so a repo's tools
-        // list in the same order (and texture) as the usage chart's legend.
+        // Which tools ran in each repository. The ledger owns that set; the
+        // ordering is presentation — series slots — so a repo's tools read in
+        // the same order (and texture) as the usage chart's legend. That is
+        // alphabetical order today, `series` being the sorted tool list, but
+        // the reorder keeps it an invariant rather than a coincidence.
         let mut tools_by_repo: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for tool in &self.series {
-            for meta in self.ledger().session_meta.values() {
-                if meta.tool == *tool {
-                    let entry = tools_by_repo.entry(meta.repo.clone()).or_default();
-                    if !entry.contains(tool) {
-                        entry.push(tool.clone());
-                    }
-                }
-            }
+        for (repo, set) in self.ledger().tools_by_repo() {
+            let mut tools: Vec<String> = set.into_iter().collect();
+            tools.sort_by_key(|tool| {
+                self.series
+                    .iter()
+                    .position(|s| s == tool)
+                    .unwrap_or(usize::MAX)
+            });
+            tools_by_repo.insert(repo, tools);
         }
 
         let mut repos: Vec<RepoRow> = self

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -357,6 +357,24 @@ impl Ledger {
         totals
     }
 
+    /// The tools whose sessions ran in each repository, from the session
+    /// metadata [`observe_session`](Self::observe_session) keeps.
+    ///
+    /// The projects map itself has no tool axis, so this answers "which tools
+    /// ran here", not "which tool produced every token": attribution is per
+    /// session and first-wins, so a session that moved between checkouts
+    /// marks only the repository it started in.
+    pub fn tools_by_repo(&self) -> BTreeMap<String, BTreeSet<String>> {
+        let mut tools: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        for meta in self.session_meta.values() {
+            tools
+                .entry(meta.repo.clone())
+                .or_default()
+                .insert(meta.tool.clone());
+        }
+        tools
+    }
+
     /// Daily rows per repository, newest first — [`rows`](Self::rows) with the
     /// project axis in place of the tool one.
     ///

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1313,8 +1313,9 @@ fn draw_projects(frame: &mut Frame, area: Rect, app: &App) -> (Option<Rows>, Opt
 
     // Side by side, both tables give up columns: 88 columns of project table and
     // 96 of session table cannot share 100. The projects table keeps the three
-    // figures a ranking is read for — name, tokens, money — and sheds the rest,
-    // which the breakdown beside it carries anyway.
+    // figures a ranking is read for — name, tokens, money — plus the tools that
+    // produced them, and sheds the rest, which the breakdown beside it carries
+    // anyway.
     let (table_area, session_area) = if beside {
         let split = Layout::default()
             .direction(Direction::Horizontal)
@@ -1325,12 +1326,9 @@ fn draw_projects(frame: &mut Frame, area: Rect, app: &App) -> (Option<Rows>, Opt
         (rows[1], None)
     };
 
-    let peak = repos.iter().map(|r| r.tokens).max().unwrap_or(1).max(1);
-
     let table_rows: Vec<Row> = repos
         .iter()
         .map(|r| {
-            let bar = ((r.tokens as f64 / peak as f64) * 12.0).round() as usize;
             // A repo with unpriced models under it has a floor, not a total.
             let (amount, style) = if r.unpriced > 0 {
                 (
@@ -1343,12 +1341,9 @@ fn draw_projects(frame: &mut Frame, area: Rect, app: &App) -> (Option<Rows>, Opt
             let name = Cell::from(truncate(&r.repo, PROJECT_W));
             let tokens = Cell::from(theme::compact(r.tokens));
             let money = Cell::from(Line::from(Span::styled(amount, style)));
-            let share = Cell::from(Line::from(Span::styled(
-                "\u{2588}".repeat(bar),
-                Style::default().fg(theme::SEQUENTIAL),
-            )));
+            let tools = Cell::from(tools_line(app.series(), &r.tools));
             if beside {
-                Row::new(vec![name, tokens, money, share])
+                Row::new(vec![name, tokens, money, tools])
             } else {
                 Row::new(vec![
                     name,
@@ -1359,10 +1354,7 @@ fn draw_projects(frame: &mut Frame, area: Rect, app: &App) -> (Option<Rows>, Opt
                         r.last_day.clone(),
                         Style::default().fg(theme::MUTED),
                     ))),
-                    Cell::from(Line::from(Span::styled(
-                        "\u{2588}".repeat(bar),
-                        Style::default().fg(theme::SEQUENTIAL),
-                    ))),
+                    tools,
                 ])
             }
         })
@@ -1385,11 +1377,11 @@ fn draw_projects(frame: &mut Frame, area: Rect, app: &App) -> (Option<Rows>, Opt
         });
     }
 
-    // The share bar takes the slack, not the name column: a fixed name column
-    // keeps the figures in the same place on a wide terminal as on a narrow one.
+    // The tools column takes the slack, not the name column: a fixed name
+    // column keeps the figures in the same place on a wide terminal as on a
+    // narrow one, and a tool list that runs out of room clips names rather
+    // than moving money.
     let (widths, labels) = if beside {
-        // Same doctrine as the wide table: the name column is fixed and the share
-        // bar takes the slack, so the figures do not wander as the split moves.
         (
             vec![
                 Constraint::Length(PROJECT_W as u16 + 2),
@@ -1397,7 +1389,7 @@ fn draw_projects(frame: &mut Frame, area: Rect, app: &App) -> (Option<Rows>, Opt
                 Constraint::Length(12),
                 Constraint::Min(4),
             ],
-            vec!["PROJECT", "TOKENS", "COST", ""],
+            vec!["PROJECT", "TOKENS", "COST", "TOOLS"],
         )
     } else {
         (
@@ -1409,7 +1401,14 @@ fn draw_projects(frame: &mut Frame, area: Rect, app: &App) -> (Option<Rows>, Opt
                 Constraint::Length(12),
                 Constraint::Min(14),
             ],
-            vec!["PROJECT", "TOKENS", "MESSAGES", "COST", "LAST USED", ""],
+            vec![
+                "PROJECT",
+                "TOKENS",
+                "MESSAGES",
+                "COST",
+                "LAST USED",
+                "TOOLS",
+            ],
         )
     };
 
@@ -1696,6 +1695,29 @@ fn series_dot(series: &[String], tool: &str) -> Span<'static> {
         }
         None => Span::styled("\u{b7} ", Style::default().fg(theme::MUTED)),
     }
+}
+
+/// The tools that ran in a repository, each behind its series dot — the same
+/// texture the usage chart and the session breakdown key that tool by, so a
+/// row and a segment are visibly one thing. A repo with no observed sessions
+/// (a ledger written before tools were recorded) shows a muted `·`, not
+/// nothing: an empty cell would read as "no tool", which is never true.
+fn tools_line(series: &[String], tools: &[String]) -> Line<'static> {
+    if tools.is_empty() {
+        return Line::from(Span::styled("\u{b7}", Style::default().fg(theme::MUTED)));
+    }
+    let mut spans = Vec::new();
+    for tool in tools {
+        if !spans.is_empty() {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(series_dot(series, tool));
+        spans.push(Span::styled(
+            tool.clone(),
+            Style::default().fg(theme::MUTED),
+        ));
+    }
+    Line::from(spans)
 }
 
 /// The token split, for the detail line under a row's name.
@@ -2168,6 +2190,59 @@ mod tests {
         for column in ["PROJECT", "TOKENS", "COST"] {
             assert!(beside.contains(column), "the narrow table dropped {column}");
         }
+    }
+
+    /// The tools column is what tells `HAI Neo` under Codex apart from
+    /// `owner/hai-neo` under Claude Code — nothing else on the row can.
+    #[test]
+    fn the_projects_table_names_the_tool_behind_each_repository() {
+        let mut ledger = Ledger::default();
+        let t = tokens(1_000, 2_000);
+        // Session *metadata* only, no session token rows: the breakdown pane
+        // then stands down at any width, so the tool must be readable from
+        // the table itself.
+        ledger.add("2026-07-26", "claude_code", "claude-opus-5", &t);
+        ledger.add_project("2026-07-26", "acme/widgets", "claude-opus-5", &t);
+        ledger.observe_session("a", "claude_code", "acme/widgets", None);
+        ledger.add("2026-07-27", "codex", "gpt-5.6", &t);
+        ledger.add_project("2026-07-27", "other/thing", "gpt-5.6", &t);
+        ledger.observe_session("z", "codex", "other/thing", None);
+
+        let scan = Scan {
+            tools_summary: Default::default(),
+            tools: Vec::new(),
+            #[cfg(feature = "sqlite")]
+            sites: Default::default(),
+            usage: crate::scan::usage::Usage {
+                ledger,
+                window_days: 30,
+                ..Default::default()
+            },
+            failed: Vec::new(),
+            demo: false,
+        };
+        let mut app = App::new(
+            scan,
+            Timings::default(),
+            crate::pricing::Prices::default(),
+            CostConfig::default(),
+        );
+        app.set_tab(Tab::Projects);
+
+        let out = rendered(&app, 150, 30);
+        assert!(out.contains("TOOLS"), "the tools column header");
+        assert!(out.contains("claude_code"), "the Claude Code repo says so");
+        assert!(out.contains("codex"), "the Codex repo says so");
+    }
+
+    /// Beside the breakdown the column survives, because that is the layout a
+    /// wide terminal actually shows.
+    #[test]
+    fn the_tools_column_survives_the_side_by_side_split() {
+        let mut app = two_projects_with_sessions();
+        app.set_tab(Tab::Projects);
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("TOOLS"), "the tools column header");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1699,9 +1699,10 @@ fn series_dot(series: &[String], tool: &str) -> Span<'static> {
 
 /// The tools that ran in a repository, each behind its series dot — the same
 /// texture the usage chart and the session breakdown key that tool by, so a
-/// row and a segment are visibly one thing. A repo with no observed sessions
-/// (a ledger written before tools were recorded) shows a muted `·`, not
-/// nothing: an empty cell would read as "no tool", which is never true.
+/// row and a segment are visibly one thing. A repo whose sessions are all
+/// pinned to another repository (session attribution is first-wins) shows a
+/// muted `·`, not nothing: an empty cell would read as "no tool", which is
+/// never true.
 fn tools_line(series: &[String], tools: &[String]) -> Line<'static> {
     if tools.is_empty() {
         return Line::from(Span::styled("\u{b7}", Style::default().fg(theme::MUTED)));
@@ -2239,8 +2240,7 @@ mod tests {
     /// wide terminal actually shows.
     #[test]
     fn the_tools_column_survives_the_side_by_side_split() {
-        let mut app = two_projects_with_sessions();
-        app.set_tab(Tab::Projects);
+        let app = two_projects_with_sessions();
         let out = rendered(&app, 150, 40);
         assert!(out.contains("TOOLS"), "the tools column header");
     }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -175,7 +175,7 @@ pub fn model_swatch(slot: usize) -> (&'static str, Color) {
     ("\u{2588}", model(slot))
 }
 
-/// Magnitude bars in the tables — the `TOTAL` and share columns.
+/// Magnitude bars in the tables — the `TOTAL` and `VISITS` columns.
 ///
 /// Ash, so a solid run of `█` reads as a bar rather than as a line of text. It is
 /// deliberately not a series texture: these bars rank rows within one column and


### PR DESCRIPTION
## What

The Projects view gave no way to tell which tool a repository's spend came from — two rows like `HAI Neo` and `owner/hai-neo` are indistinguishable as \"the Codex checkout\" and \"the Claude Code one\". Each project row now ends in a **TOOLS** column naming the tools whose sessions ran there, each behind the same series texture dot the usage chart and session breakdown key that tool by.

## How

- `RepoRow` carries `tools: Vec<String>`, derived from the session metadata the ledger already keeps — the projects map has no tool axis, and adding one would mean a ledger schema bump for a fact the sessions carry. The list follows series order, so it reads in the same order (and texture) as the usage chart legend.
- The column replaces the share bar in both table layouts. The bar repeated TOKENS as decoration; the tools are information, and the swap keeps every width budget exactly where it was.
- A repo with no observed sessions (a ledger written before tools were recorded) shows a muted `·` rather than an empty cell, which would read as \"no tool\".

## Verification

Two new tests: the full-width table names the tool behind each repository (fixture with a Claude Code repo and a Codex repo), and the column survives the side-by-side split. `cargo fmt`, `clippy -D warnings`, all 245 tests pass; verified live against a real ledger with mixed Claude Code / Codex repositories, and `--demo` populates the column via its per-tool session metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)