### PR TITLE
feat(ui): the SPEND card says its dollars are list-rate arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ publishing empty notes.
 
 ## [Unreleased]
 
+### Changed
+
+- **The SPEND card says what its dollars are.** Its last qualifier now reads
+  `at API list rates` instead of `all models priced` — the figure is list-rate
+  arithmetic, not a bill, and the old line said nothing the absence of `≥`
+  did not already say. With unpriced models the `▲ N model(s) unpriced`
+  caveat still takes the line.
+
 ## [0.1.0] - 2026-07-28
 
 First release.

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -58,7 +58,7 @@ one of those is a caveat rather than a count.
 
 | Card | Figure | Qualifiers |
 |---|---|---|
-| **SPEND** | Total cost over the window | `over N days · ≈ $X/day`, the period delta, and `▲ N model(s) unpriced` if any |
+| **SPEND** | Total cost over the window | `over N days · ≈ $X/day`, the period delta, and `▲ N model(s) unpriced` — or `at API list rates` when none are, because the figure is list-rate arithmetic, not a bill |
 | **TOKENS** | Everything billable, cache included | Message count, distinct model count |
 | **TOOLS** | AI tools detected | `▲ N autonomous`, vendor count |
 | **AI SITES** | Distinct AI domains visited | Visit total, and `▲ N browser(s) unreadable` if any |

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -495,10 +495,14 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
             trend.days
         ));
     }
+    // The figure is list-rate arithmetic, not a bill, and the card must say so:
+    // "SPEND" alone reads as money out the door, which for a subscription user
+    // it is not. With unpriced models the caveat line matters more — and `≥` on
+    // the figure plus the amber are already carrying "estimate".
     spend_detail.push(if unpriced > 0 {
         format!("\u{25b2} {unpriced} model(s) unpriced")
     } else {
-        "all models priced".to_string()
+        "at API list rates".to_string()
     });
 
     card(
@@ -2147,6 +2151,32 @@ mod tests {
         let out = rendered(&app, 120, 40);
         assert!(out.contains("nothing can be costed"));
         assert!(!out.contains("$0.00"));
+    }
+
+    /// The SPEND card names what its dollars are: list-rate arithmetic when
+    /// every model is priced, the unpriced caveat when one is not — one line,
+    /// never both.
+    #[test]
+    fn the_spend_card_qualifies_its_dollars() {
+        let all_priced = crate::pricing::Prices::parse(
+            r#"{"claude-opus-5": {"input_cost_per_token": 0.000005,
+                                  "output_cost_per_token": 0.000025},
+                "gpt-5.6-sol": {"input_cost_per_token": 0.000001,
+                                "output_cost_per_token": 0.000004}}"#,
+        )
+        .expect("a two-model table parses");
+        let mut app = populated_with(all_priced);
+        app.set_tab(Tab::Overview);
+        let out = rendered(&app, 120, 40);
+        assert!(out.contains("at API list rates"), "the qualifier line");
+        assert!(!out.contains("unpriced"), "nothing is unpriced");
+
+        // One of the fixture's two models is missing from this table.
+        let mut app = populated_with(prices_for_a_model());
+        app.set_tab(Tab::Overview);
+        let out = rendered(&app, 120, 40);
+        assert!(out.contains("unpriced"), "the caveat takes the line");
+        assert!(!out.contains("at API list rates"), "one line, never both");
     }
 
     #[test]


### PR DESCRIPTION
## What

The Overview's SPEND card shows a bold dollar figure that reads as money out the door — but the figure is tokens priced at API list rates, which for a subscription user is not a bill. The card now says so.

## How

The card's last qualifier line reads `at API list rates` in place of `all models priced`. The old line carried no information the figure didn't already carry — the absence of `≥` means no floors — so the swap adds the qualifier without growing the card (card height drives the Overview's responsive band-shedding, so an extra row would ripple).

When models are unpriced, the `▲ N model(s) unpriced` caveat still takes the line: in that state the `≥` floor marker and the amber are already carrying "estimate", and the caveat matters more.

The chart title keeps its existing `estimated spend` phrasing, which already qualifies itself. Docs (`dashboard.md` card table) and CHANGELOG updated; the phrasing matches the language `README`, `costs.md`, and `configuration.md` already use ("API list rates").

## Verification

New test `the_spend_card_qualifies_its_dollars` pins both states: all-priced shows the qualifier and no caveat, one-unpriced shows the caveat and not the qualifier — one line, never both. `cargo fmt`, `clippy -D warnings`, all 244 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)