### PR TITLE
feat(ui): the Overview cards say what kind of money they are, in order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,17 @@ publishing empty notes.
   arithmetic, not a bill, and the old line said nothing the absence of `≥`
   did not already say. With unpriced models the `▲ N model(s) unpriced`
   caveat still takes the line.
-  
+- **The Overview cards say what kind of money they are, in order.** SPEND,
+  TOKENS, TOKEN COST, AVG USAGE RATE, TOOLS & SITES — the actual bill first,
+  the work done, the API-rate hypothetical it would have cost, how hard the
+  plan is being driven, the machine's inventory last. SPEND now carries only
+  real money: the saving-vs-API-rates line moved off it (the comparison lives
+  on TOKEN COST and in the Cost view), and in its place the card says whether
+  extra usage is in play — `no extra usage` while the metering windows have
+  never pegged, `▲ extra usage likely` once one has. AVG USAGE RATE is new:
+  the mean peak of the 5-hour metering windows, the number that predicts a
+  cap hit before it bills. TOOLS and AI SITES folded into one card.
+
 ### Added
 
 - **A SPEND card that prices seats, and a TOKEN COST card that prices tokens.**

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -59,21 +59,23 @@ one of those is a caveat rather than a count.
 
 | Card | Figure | Qualifiers |
 |---|---|---|
-| **SPEND** | What the seats actually cost, `$X/mo` | Where the figures came from (`N configured seat(s)`, `N plan(s) detected`), the saving against API rates, and `▲ N tool(s) unpriced` if any |
-| **TOKEN COST** | The window's tokens at API list rates | `over N days · ≈ $X/day`, the period delta, and `▲ N model(s) unpriced` — or `at API list rates` when none are, because the figure is list-rate arithmetic, not a bill |
+| **SPEND** | What is actually paid: the seats, `$X/mo` | Where the figures came from (`N configured seat(s)`, `N plan(s) detected`), whether extra usage is in play (`no extra usage`, or `▲ extra usage likely` once a metering window has pegged), and `▲ N tool(s) unpriced` if any |
 | **TOKENS** | Everything billable, cache included | Message count, distinct model count |
-| **TOOLS** | AI tools detected | `▲ N autonomous`, vendor count |
-| **AI SITES** | Distinct AI domains visited | Visit total, and `▲ N browser(s) unreadable` if any |
+| **TOKEN COST** | The window's tokens at API list rates | `over N days · ≈ $X/day`, the period delta, and `▲ N model(s) unpriced` — or `at API list rates` when none are, because the figure is list-rate arithmetic, not a bill |
+| **AVG USAGE RATE** | Mean peak of the 5-hour metering windows | Window count, hottest window (`▲` amber from 90%), and the pointer to <kbd>m</kbd> on Usage for the per-day breakdown |
+| **TOOLS & SITES** | Installed tools `·` AI domains visited | `▲ N autonomous`, visit total, and `▲ N browser(s) unreadable` if any |
 
-SPEND and TOKEN COST are different questions about the same tokens. TOKEN COST
-is arithmetic — the window's usage priced per token at list rates. SPEND is
-what is actually paid for the seats behind that usage: a figure from
-`[cost.subscriptions]` is shown plainly; one from a plan the tool's own
-transcripts name (Codex writes `plan_type` beside its token counts) is priced
-at that plan's list rate and marked `≈` an estimate; a tool with usage but no
-figure makes the total `≥` a floor. Knowing nothing, the card shows `–` and
-says how to configure it — it never guesses, and it still reads no account
-state.
+The order is deliberate: the actual bill first, then the work done, then what
+that work *would* have cost, then how hard the plan is being driven, then the
+machine's inventory. SPEND carries only real money — seats from
+`[cost.subscriptions]` shown plainly, a plan the tool itself names priced at
+list rate and marked `≈` an estimate, a tool with usage but no figure making
+the total `≥` a floor — and the API-rate hypothetical never appears on it;
+that comparison lives on TOKEN COST and in the Cost view. Knowing nothing,
+SPEND shows `–` and says how to configure it — it never guesses, and it still
+reads no account state. AVG USAGE RATE comes from the same metering samples
+as the Usage view's <kbd>m</kbd> toggle, and shows `–` on a machine without
+them rather than a zero that would read as idleness.
 
 ### The rate and the delta
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2394,6 +2394,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2440,6 +2441,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -459,6 +459,10 @@ fn draw_rankings(frame: &mut Frame, area: Rect, app: &App) {
     draw_ranking(frame, columns[2], "by repository", &by_repo, app);
 }
 
+/// Money the reader pays, work the reader did, what that work would have
+/// cost, how hard the plan is being driven, and what is installed — in that
+/// order, left to right: the actual bill first, the hypothetical after the
+/// facts it is derived from, the machine's inventory last.
 fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
     let cards = Layout::default()
         .direction(Direction::Horizontal)
@@ -467,13 +471,27 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
 
     draw_spend_card(frame, cards[0], app);
 
+    card(
+        frame,
+        cards[1],
+        "tokens",
+        &theme::compact(app.total_tokens()),
+        &[
+            format!("{} messages", thousands(app.total_messages())),
+            // Distinct models, not the `(tool, model)` pairs `models()` lists: one
+            // model run by two tools was counted twice here.
+            format!("{} models", app.distinct_models()),
+        ],
+        theme::TEXT,
+    );
+
     let unpriced = app.unpriced_models();
     // A total with nothing to compare it against is the least useful shape a cost
     // figure can take, so the window line carries a projected rate and the line
     // under it says which way the spend is going. Both are dropped rather than
     // faked when they cannot be computed — a zero-day window, or too few active
     // days for a half-against-half comparison to mean anything.
-    let mut spend_detail = vec![match app.daily_rate() {
+    let mut cost_detail = vec![match app.daily_rate() {
         Some(rate) => format!(
             "over {} days \u{b7} \u{2248} {}/day",
             app.scan.usage.window_days,
@@ -491,17 +509,17 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
         } else {
             "\u{25bc}"
         };
-        spend_detail.push(format!(
+        cost_detail.push(format!(
             "{arrow} {:.0}% vs prior {} days",
             trend.change.abs() * 100.0,
             trend.days
         ));
     }
     // The figure is list-rate arithmetic, not a bill, and the card must say so:
-    // "SPEND" alone reads as money out the door, which for a subscription user
-    // it is not. With unpriced models the caveat line matters more — and `≥` on
-    // the figure plus the amber are already carrying "estimate".
-    spend_detail.push(if unpriced > 0 {
+    // "TOKEN COST" is the hypothetical beside SPEND's actual. With unpriced
+    // models the caveat line matters more — and `≥` on the figure plus the
+    // amber are already carrying "estimate".
+    cost_detail.push(if unpriced > 0 {
         format!("\u{25b2} {unpriced} model(s) unpriced")
     } else {
         "at API list rates".to_string()
@@ -509,10 +527,10 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
 
     card(
         frame,
-        cards[1],
+        cards[2],
         "token cost",
         &format_usd(app.total_usd()),
-        &spend_detail,
+        &cost_detail,
         if unpriced > 0 {
             theme::WARN
         } else {
@@ -520,67 +538,41 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
         },
     );
 
-    card(
-        frame,
-        cards[2],
-        "tokens",
-        &theme::compact(app.total_tokens()),
-        &[
-            format!("{} messages", thousands(app.total_messages())),
-            // Distinct models, not the `(tool, model)` pairs `models()` lists: one
-            // model run by two tools was counted twice here.
-            format!("{} models", app.distinct_models()),
-        ],
-        theme::TEXT,
-    );
-
-    let s = &app.scan.tools_summary;
-    card(
-        frame,
-        cards[3],
-        "tools",
-        &s.detected.to_string(),
-        &[
-            if s.autonomous > 0 {
-                format!("\u{25b2} {} autonomous", s.autonomous)
-            } else {
-                "none autonomous".to_string()
-            },
-            format!("{} vendors", s.vendors.len()),
-        ],
-        if s.autonomous > 0 {
-            theme::WARN
-        } else {
-            theme::TEXT
-        },
-    );
-
-    draw_sites_card(frame, cards[4], app);
+    draw_meter_card(frame, cards[3], app);
+    draw_tools_sites_card(frame, cards[4], app);
 }
 
-/// What the seats actually cost, as far as that can be known — against the
-/// token arithmetic on the TOKEN COST card beside it.
+/// What is actually paid: seats, and whether overflow billing is in play.
 ///
-/// Three states, in the house grammar: a configured figure is plain, a
-/// detected plan's list price is `≈` an estimate, a tool with usage but no
-/// figure makes the total `≥` a floor — and knowing nothing shows `–` and
-/// says how to fix it, never a guess.
+/// Only real money lives here — the API-rate hypothetical has its own card,
+/// TOKEN COST, and never leaks into this one. Three states, in the house
+/// grammar: a configured figure is plain, a detected plan's list price is `≈`
+/// an estimate, a tool with usage but no figure makes the total `≥` a floor —
+/// and knowing nothing shows `–` and says how to fix it, never a guess.
 fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
+    // Extra usage bills only after a metering window pegs at 100%, so the
+    // meter is the honest witness: never pegged means none, a peg means it
+    // is likely, and no meter history means nothing is claimed either way.
+    let extra_usage = |metering: &crate::scan::meter::Metering| -> Option<String> {
+        if !metering.found || metering.windows.is_empty() {
+            return None;
+        }
+        Some(if metering.hottest() >= 100 {
+            "\u{25b2} extra usage likely".to_string()
+        } else {
+            "no extra usage".to_string()
+        })
+    };
+
     let Some(estimate) = app.spend_estimate() else {
         // Card lines have ~24 columns on a 150-column terminal; every string
         // here is written to that width rather than truncated into noise.
-        card(
-            frame,
-            area,
-            "spend",
-            "\u{2013}",
-            &[
-                "no seat price known".to_string(),
-                "set [cost.subscriptions]".to_string(),
-                "see token cost".to_string(),
-            ],
-            theme::DIM,
-        );
+        let mut detail = vec![
+            "no seat price known".to_string(),
+            "set [cost.subscriptions]".to_string(),
+        ];
+        detail.extend(extra_usage(&app.scan.metering));
+        card(frame, area, "spend", "\u{2013}", &detail, theme::DIM);
         return;
     };
 
@@ -600,14 +592,7 @@ fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
         (0, d) => format!("{d} plan(s) detected"),
         (c, d) => format!("{c} configured \u{b7} {d} detected"),
     }];
-    // The comparison the Cost view makes per tool, summed: the same tools'
-    // window tokens at API rates. Signed like `SubscriptionRow::saving`.
-    let saving = estimate.api_equivalent - estimate.monthly_usd;
-    detail.push(if saving >= 0.0 {
-        format!("{} under API rates", format_usd(saving))
-    } else {
-        format!("{} over API rates", format_usd(-saving))
-    });
+    detail.extend(extra_usage(&app.scan.metering));
     if estimate.unpriced_tools > 0 {
         detail.push(format!(
             "\u{25b2} {} tool(s) unpriced",
@@ -615,13 +600,14 @@ fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
         ));
     }
 
+    let pegged = app.scan.metering.found && app.scan.metering.hottest() >= 100;
     card(
         frame,
         area,
         "spend",
         &value,
         &detail,
-        if estimate.unpriced_tools > 0 {
+        if estimate.unpriced_tools > 0 || pegged {
             theme::WARN
         } else {
             theme::MONEY
@@ -629,16 +615,68 @@ fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
     );
 }
 
+/// How hard the plan itself is being driven: the average peak the 5-hour
+/// metering windows reach. The number that predicts a future cap hit — and
+/// the overflow billing behind it — which no token count can.
+fn draw_meter_card(frame: &mut Frame, area: Rect, app: &App) {
+    let metering = &app.scan.metering;
+    if !metering.found || metering.windows.is_empty() {
+        card(
+            frame,
+            area,
+            "avg usage rate",
+            "\u{2013}",
+            &[
+                "no metering history".to_string(),
+                "needs Claude Desktop".to_string(),
+            ],
+            theme::DIM,
+        );
+        return;
+    }
+
+    let hottest = metering.hottest();
+    card(
+        frame,
+        area,
+        "avg usage rate",
+        &format!("{}%", metering.average_peak()),
+        &[
+            format!("{} 5-hour window(s)", metering.windows.len()),
+            if hottest >= 90 {
+                format!("\u{25b2} hottest {hottest}%")
+            } else {
+                format!("hottest {hottest}%")
+            },
+            // The per-day breakdown lives one keypress away.
+            "[m] on Usage for days".to_string(),
+        ],
+        if hottest >= 90 {
+            theme::WARN
+        } else {
+            theme::TEXT
+        },
+    );
+}
+
+/// The machine's inventory, folded into one card: what is installed, and
+/// where this machine goes. The Tools and Sites views carry the detail.
 #[cfg(feature = "sqlite")]
-fn draw_sites_card(frame: &mut Frame, area: Rect, app: &App) {
+fn draw_tools_sites_card(frame: &mut Frame, area: Rect, app: &App) {
+    let s = &app.scan.tools_summary;
     let sites = &app.scan.sites;
     let blind = sites.blind_spots.len();
     card(
         frame,
         area,
-        "AI sites",
-        &sites.sites.len().to_string(),
+        "tools & sites",
+        &format!("{} \u{b7} {}", s.detected, sites.sites.len()),
         &[
+            if s.autonomous > 0 {
+                format!("\u{25b2} {} autonomous", s.autonomous)
+            } else {
+                "none autonomous".to_string()
+            },
             format!("{} visits", thousands(sites.total_visits())),
             if blind > 0 {
                 format!("\u{25b2} {blind} browser(s) unreadable")
@@ -646,22 +684,36 @@ fn draw_sites_card(frame: &mut Frame, area: Rect, app: &App) {
                 format!("{} profile(s) read", sites.profiles_scanned)
             },
         ],
-        if blind > 0 { theme::WARN } else { theme::TEXT },
+        if s.autonomous > 0 || blind > 0 {
+            theme::WARN
+        } else {
+            theme::TEXT
+        },
     );
 }
 
 #[cfg(not(feature = "sqlite"))]
-fn draw_sites_card(frame: &mut Frame, area: Rect, _app: &App) {
+fn draw_tools_sites_card(frame: &mut Frame, area: Rect, app: &App) {
+    let s = &app.scan.tools_summary;
     card(
         frame,
         area,
-        "AI sites",
-        "\u{2013}",
+        "tools & sites",
+        &s.detected.to_string(),
         &[
-            "not compiled in".to_string(),
+            if s.autonomous > 0 {
+                format!("\u{25b2} {} autonomous", s.autonomous)
+            } else {
+                "none autonomous".to_string()
+            },
+            "sites: not compiled in".to_string(),
             "needs the sqlite feature".to_string(),
         ],
-        theme::DIM,
+        if s.autonomous > 0 {
+            theme::WARN
+        } else {
+            theme::DIM
+        },
     );
 }
 
@@ -2412,6 +2464,10 @@ mod tests {
             "the team list price, flagged an estimate"
         );
         assert!(out.contains("1 plan(s) detected"));
+        assert!(
+            !out.contains("API rates"),
+            "the hypothetical never leaks onto SPEND"
+        );
     }
 
     #[test]
@@ -2465,6 +2521,107 @@ mod tests {
             "configured is not an estimate"
         );
         assert!(out.contains("1 tool(s) unpriced"));
+        assert!(
+            !out.contains("API rates"),
+            "the hypothetical never leaks onto SPEND"
+        );
+    }
+
+    /// The SPEND card's extra-usage line follows the meter: quiet windows say
+    /// so, a pegged one flips the warning, and no history claims nothing.
+    #[test]
+    fn the_spend_card_reports_extra_usage_from_the_meter() {
+        let mut ledger = Ledger::default();
+        ledger.add("2026-07-26", "codex", "gpt-5.6", &tokens(1_000, 2_000));
+
+        let scan = Scan {
+            tools_summary: Default::default(),
+            tools: Vec::new(),
+            #[cfg(feature = "sqlite")]
+            sites: Default::default(),
+            usage: crate::scan::usage::Usage {
+                ledger,
+                window_days: 30,
+                ..Default::default()
+            },
+            metering: crate::scan::meter::Metering {
+                windows: vec![crate::scan::meter::MeterWindow {
+                    day: "2026-07-26".to_string(),
+                    peak: 45,
+                }],
+                from: Some("2026-07-26".to_string()),
+                to: Some("2026-07-26".to_string()),
+                found: true,
+            },
+            failed: Vec::new(),
+            demo: false,
+        };
+        let mut cost = CostConfig::default();
+        cost.subscriptions.insert("codex".into(), 25.0);
+        let mut app = App::new(
+            scan,
+            Timings::default(),
+            crate::pricing::Prices::default(),
+            cost,
+        );
+        app.set_tab(Tab::Overview);
+
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("no extra usage"), "quiet windows say so");
+
+        app.scan
+            .metering
+            .windows
+            .push(crate::scan::meter::MeterWindow {
+                day: "2026-07-27".to_string(),
+                peak: 100,
+            });
+        let out = rendered(&app, 150, 40);
+        assert!(
+            out.contains("\u{25b2} extra usage likely"),
+            "a pegged window flips the warning"
+        );
+    }
+
+    /// The AVG USAGE RATE card averages the window peaks, and a machine
+    /// without metering history shows the absence rather than a zero.
+    #[test]
+    fn the_avg_usage_rate_card_averages_window_peaks() {
+        let mut app = populated();
+        app.set_tab(Tab::Overview);
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("AVG USAGE RATE"), "the card exists");
+        assert!(out.contains("no metering history"), "absence, not zero");
+
+        app.scan.metering = crate::scan::meter::Metering {
+            windows: vec![
+                crate::scan::meter::MeterWindow {
+                    day: "2026-07-26".to_string(),
+                    peak: 30,
+                },
+                crate::scan::meter::MeterWindow {
+                    day: "2026-07-27".to_string(),
+                    peak: 50,
+                },
+            ],
+            from: Some("2026-07-26".to_string()),
+            to: Some("2026-07-27".to_string()),
+            found: true,
+        };
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("40%"), "(30 + 50) / 2");
+        assert!(out.contains("hottest 50%"));
+        assert!(out.contains("2 5-hour window(s)"));
+    }
+
+    /// Tools and sites share one card, in the fifth slot.
+    #[test]
+    fn tools_and_sites_share_one_card() {
+        let mut app = populated();
+        app.set_tab(Tab::Overview);
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("TOOLS & SITES"), "the folded card");
+        assert!(!out.contains("AI SITES"), "the separate card is gone");
     }
 
     /// `m` swaps the Usage view for the plan's own meter and back, shows the


### PR DESCRIPTION
> **#44 has merged; base is now `feat/metering-view` (#51).** The review surface is this PR's own commits — #51's metering work is the base, not the diff. When #51 lands this retargets to `main` automatically. Landing order: #51 → this.

## What

The Overview cards reorder to say what kind of money each one is, left to right: **SPEND, TOKENS, TOKEN COST, AVG USAGE RATE, TOOLS & SITES** — the actual bill first, the work done, the API-rate hypothetical it would have cost, how hard the plan is being driven, the machine's inventory last.

## SPEND carries only real money now

The saving-vs-API-rates line moves off the SPEND card — that comparison is the hypothetical's business, and it lives on TOKEN COST and in the Cost view. In its place the card answers the question actual spend turns on: **is overflow billing in play?** Driven by the metering samples, in the honest grammar:

- `no extra usage` — the windows have never pegged (extra usage bills only past 100%).
- `▲ extra usage likely` + amber — a window has pegged (the conservative trigger from #50's design).
- Nothing claimed on a machine without metering history.

Two tests pin that no `API rates` string can appear on the Overview when SPEND renders with figures (the phrase only ever comes from TOKEN COST's own qualifier).

## AVG USAGE RATE is new

The mean peak of the 5-hour metering windows — the number that predicts a cap hit before it bills, which no token count can. Qualifiers: window count, hottest window (`▲` amber from 90%), and the `[m]` pointer to the per-day breakdown on Usage. Shows `–` with the absence stated on machines without Claude Desktop's samples.

## TOOLS & SITES fold into one card

`9 · 12`-style headline, keeping the `▲ autonomous` and `▲ browser(s) unreadable` warnings and the visit total. Both cfg variants handled (non-sqlite builds say sites are not compiled in).

## Verification

Three new tests (extra-usage line follows the meter through quiet → pegged; AVG USAGE RATE averages peaks and states absence; the folded card exists and `AI SITES` is gone) plus the no-API-rates-on-SPEND assertions. `cargo fmt`, `clippy -D warnings`, 268 tests pass on the branch. Docs: the Overview card table and order rationale in `dashboard.md`; CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
