### PR TITLE
feat(ui): the cost cards say what kind of money they are, and the plan gets its own meter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ publishing empty notes.
 
 ## [Unreleased]
 
+### Added
+
+- **`[usage.repo_aliases]` folds two names for one project into one row.** A
+  checkout with an `origin` remote reports `owner/name`; a copy of the same
+  code with no remote reports its folder basename; and surface never guesses
+  the two are the same project, because folding spend together on a string
+  resemblance is misattribution. The operator declares it instead —
+  `"HAI Neo" = "holistic-ai/hai-neo"` — and the grouping applies when the
+  ledger is read, never to what is stored, so history regroups retroactively
+  and a wrong alias is one edit away from undone. Project totals, daily rows
+  and the session breakdown all follow the alias.
+
 ## [0.1.0] - 2026-07-28
 
 First release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ publishing empty notes.
 
 ## [Unreleased]
 
+### Added
+
+- **The Usage view can show the plan's own meter.** <kbd>m</kbd> swaps the
+  token table for Claude's 5-hour metering windows — per day, how many were
+  started and the peak utilisation each reached, with the deepest window
+  drawn as a bar against the cap itself. Reconstructed from the samples
+  Claude Desktop already keeps in `plan-usage-history.json`; timestamps and
+  percentages are all that is read, the org id in the file is never kept, and
+  a machine without the file gets the absence stated rather than a zero. The
+  window count is a floor — samples exist only while Claude Desktop runs.
+
 ## [0.1.0] - 2026-07-28
 
 First release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,17 @@ publishing empty notes.
   arithmetic, not a bill, and the old line said nothing the absence of `≥`
   did not already say. With unpriced models the `▲ N model(s) unpriced`
   caveat still takes the line.
-  
+- **The Overview cards say what kind of money they are, in order.** SPEND,
+  TOKENS, TOKEN COST, AVG USAGE RATE, TOOLS & SITES — the actual bill first,
+  the work done, the API-rate hypothetical it would have cost, how hard the
+  plan is being driven, the machine's inventory last. SPEND now carries only
+  real money: the saving-vs-API-rates line moved off it (the comparison lives
+  on TOKEN COST and in the Cost view), and in its place the card says whether
+  extra usage is in play — `no extra usage` while the metering windows have
+  never pegged, `▲ extra usage likely` once one has. AVG USAGE RATE is new:
+  the mean peak of the 5-hour metering windows, the number that predicts a
+  cap hit before it bills. TOOLS and AI SITES folded into one card.
+
 ### Added
 
 - **A SPEND card that prices seats, and a TOKEN COST card that prices tokens.**

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -92,6 +92,26 @@ a typo, and refusing to run over a typo is worse than running over a sane value.
 An unknown *key*, on the other hand, is an error at startup: a misspelled setting
 that silently does nothing is the worse failure.
 
+## `[usage.repo_aliases]`
+
+The same project legitimately earns two rows in the Projects view: a checkout
+with an `origin` remote reports `owner/name`, while a copy of the same code
+with no remote — a scratch workspace, an agent's own working folder — reports
+its directory basename. surface never guesses that two names are one project,
+because folding someone's spend together on a string resemblance is
+misattribution. Declare it instead:
+
+```toml
+[usage.repo_aliases]
+"HAI Neo" = "holistic-ai/hai-neo"
+```
+
+Keys are rows exactly as the Projects view shows them; values are the row to
+fold them into. The grouping is applied when the ledger is *read*, never to
+what is stored — like prices — so an alias added today regroups the whole
+window retroactively, and a wrong one is one edit away from undone. Aliases do
+not chase: an alias pointing at another alias folds one hop only.
+
 ## `[cost]`
 
 surface prices tokens at API list rates. If you pay a flat subscription instead,

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -309,7 +309,11 @@ walks projects and the chart follows.
 ```
 
 Attribution is by the working directory a session ran in, resolved to its git
-`origin` slug — never a path, and never a branch. Work outside a repository lands
+`origin` slug — never a path, and never a branch. A directory with no remote is
+named by its basename, which is how one project can appear as two rows (`HAI
+Neo` beside `holistic-ai/hai-neo`); declare those one project with
+[`[usage.repo_aliases]`](configuration.md#usagerepo_aliases) and the rows fold
+together, history included. Work outside a repository lands
 in `(unattributed)`, which is a row like any other rather than a discard — see
 [Repository
 attribution](../getting-started/concepts.md#repository-attribution).

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -59,21 +59,23 @@ one of those is a caveat rather than a count.
 
 | Card | Figure | Qualifiers |
 |---|---|---|
-| **SPEND** | What the seats actually cost, `$X/mo` | Where the figures came from (`N configured seat(s)`, `N plan(s) detected`), the saving against API rates, and `▲ N tool(s) unpriced` if any |
-| **TOKEN COST** | The window's tokens at API list rates | `over N days · ≈ $X/day`, the period delta, and `▲ N model(s) unpriced` — or `at API list rates` when none are, because the figure is list-rate arithmetic, not a bill |
+| **SPEND** | What is actually paid: the seats, `$X/mo` | Where the figures came from (`N configured seat(s)`, `N plan(s) detected`), whether extra usage is in play (`no extra usage`, or `▲ extra usage likely` once a metering window has pegged), and `▲ N tool(s) unpriced` if any |
 | **TOKENS** | Everything billable, cache included | Message count, distinct model count |
-| **TOOLS** | AI tools detected | `▲ N autonomous`, vendor count |
-| **AI SITES** | Distinct AI domains visited | Visit total, and `▲ N browser(s) unreadable` if any |
+| **TOKEN COST** | The window's tokens at API list rates | `over N days · ≈ $X/day`, the period delta, and `▲ N model(s) unpriced` — or `at API list rates` when none are, because the figure is list-rate arithmetic, not a bill |
+| **AVG USAGE RATE** | Mean peak of the 5-hour metering windows | Window count, hottest window (`▲` amber from 90%), and the pointer to <kbd>m</kbd> on Usage for the per-day breakdown |
+| **TOOLS & SITES** | Installed tools `·` AI domains visited | `▲ N autonomous`, visit total, and `▲ N browser(s) unreadable` if any |
 
-SPEND and TOKEN COST are different questions about the same tokens. TOKEN COST
-is arithmetic — the window's usage priced per token at list rates. SPEND is
-what is actually paid for the seats behind that usage: a figure from
-`[cost.subscriptions]` is shown plainly; one from a plan the tool's own
-transcripts name (Codex writes `plan_type` beside its token counts) is priced
-at that plan's list rate and marked `≈` an estimate; a tool with usage but no
-figure makes the total `≥` a floor. Knowing nothing, the card shows `–` and
-says how to configure it — it never guesses, and it still reads no account
-state.
+The order is deliberate: the actual bill first, then the work done, then what
+that work *would* have cost, then how hard the plan is being driven, then the
+machine's inventory. SPEND carries only real money — seats from
+`[cost.subscriptions]` shown plainly, a plan the tool itself names priced at
+list rate and marked `≈` an estimate, a tool with usage but no figure making
+the total `≥` a floor — and the API-rate hypothetical never appears on it;
+that comparison lives on TOKEN COST and in the Cost view. Knowing nothing,
+SPEND shows `–` and says how to configure it — it never guesses, and it still
+reads no account state. AVG USAGE RATE comes from the same metering samples
+as the Usage view's <kbd>m</kbd> toggle, and shows `–` on a machine without
+them rather than a zero that would read as idleness.
 
 ### The rate and the delta
 

--- a/docs/guide/dashboard.md
+++ b/docs/guide/dashboard.md
@@ -37,6 +37,7 @@ and the body needs the room more than the nav does.
 | <kbd>enter</kbd> | Switch pane, on a view that has two |
 | <kbd>d</kbd> | Token detail line under each row, on and off |
 | <kbd>u</kbd> | Switch the Overview chart between spend and tokens |
+| <kbd>m</kbd> | Switch the Usage view between tokens and metering windows |
 | <kbd>[</kbd>/<kbd>]</kbd> | Move the chart cursor one bucket |
 | <kbd>backspace</kbd> | Drop the chart cursor |
 | <kbd>w</kbd> | Regroup the charts by day, week or month |
@@ -193,6 +194,36 @@ Every kind of token is on the detail line under each row, which is what
 `CW` is cache creation and `R` is reasoning. Both are billed — reasoning at the
 output rate — and both are inside **TOTAL**, so before they had a line of their
 own the visible columns did not add up to the total beside them.
+
+### Metering windows
+
+<kbd>m</kbd> swaps this view for the plan's own meter. Claude plans are
+enforced in 5-hour windows — how many get started, and how deep each runs —
+and tokens say nothing about either. Claude Desktop samples that meter every
+few minutes into `plan-usage-history.json`; surface reconstructs the windows
+from those samples and shows, per day, how many were started and the peak each
+reached:
+
+| Column | Meaning |
+|---|---|
+| **DAY** | Window start date, UTC |
+| **WINDOWS** | 5-hour windows started that day |
+| **AVG PEAK** | Mean of the day's window peaks |
+| **MAX PEAK** | The day's deepest window, `▲` amber from 90% |
+| **VS CAP** | The deepest window as a bar against the cap itself — half a bar is half way to the meter, on every machine |
+
+The title carries the whole story in one line: window count, the span the
+samples cover, average peak, hottest ever. A window that reaches 100% and
+keeps going is where extra usage starts billing, so the peaks here are the
+early warning the token counts cannot give.
+
+Three honest limits: the samples exist only while Claude Desktop runs, so the
+window count is a floor; the reconstruction is heuristic (a sharp utilisation
+drop is read as a reset); and it is Claude-only — Codex's equivalent lives in
+its transcripts' `rate_limits` and is not read yet. A machine without the
+history file gets that stated, never a zero that would read as idleness.
+Timestamps and percentages are all that is read; the org id in the file is
+never kept.
 
 **The chart above this table is stacked by model, not by tool, and a model is the
 same colour in both.** That is the point of keying them the same way: a segment in

--- a/src/app.rs
+++ b/src/app.rs
@@ -458,7 +458,12 @@ impl App {
                 let meta = self.ledger().session_meta.get(&key);
                 SessionRow {
                     tool: meta.map(|m| m.tool.clone()).unwrap_or_default(),
-                    repo: meta.map(|m| m.repo.clone()).unwrap_or_default(),
+                    // Canonical, like the project rows, or an aliased
+                    // project's breakdown would come up empty: the pane
+                    // filters sessions by the name the row above shows.
+                    repo: meta
+                        .map(|m| self.ledger().canonical(&m.repo).to_string())
+                        .unwrap_or_default(),
                     title: meta.and_then(|m| m.title.clone()),
                     models: models.into_keys().collect(),
                     key,

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,6 +205,18 @@ impl SessionRow {
     }
 }
 
+/// One day of the plan's own meter: how many 5-hour windows started, and how
+/// deep they ran.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeterDay {
+    pub day: String,
+    pub windows: usize,
+    /// Mean of the day's window peaks, percent.
+    pub avg_peak: u64,
+    /// Deepest window of the day, percent.
+    pub max_peak: u64,
+}
+
 /// A subscription against what the same usage would have cost on API rates.
 #[derive(Debug, Clone)]
 pub struct SubscriptionRow {
@@ -251,6 +263,10 @@ pub struct App {
     /// tables that have one. On by default: the figures it carries are billed,
     /// and they were invisible before it existed.
     pub detail: bool,
+    /// Whether the Usage view shows the plan's own meter — the 5-hour windows
+    /// and the peak each reached — instead of the token table. Off by
+    /// default: tokens are what the view is named for.
+    pub metering_view: bool,
     pub should_quit: bool,
     pub status_line: Option<String>,
 
@@ -288,6 +304,7 @@ impl App {
             bucket_back: None,
             unit: Unit::Spend,
             detail: true,
+            metering_view: false,
             should_quit: false,
             status_line: None,
             tools: Vec::new(),
@@ -738,6 +755,9 @@ impl App {
             Tab::Overview => 0,
             Tab::Tools => self.tools.len(),
             Tab::Sites => self.site_count(),
+            // The meter has nothing to select: its rows are days, and no
+            // second pane hangs off them.
+            Tab::Usage if self.metering_view => 0,
             Tab::Usage => self.models.len(),
             // Nothing to select over when there are no prices; the footer should
             // not advertise a movement that does nothing.
@@ -959,6 +979,48 @@ impl App {
             }
             .to_string(),
         );
+    }
+
+    /// Swap the Usage view between tokens and the plan's own meter. A no-op
+    /// on every other view, so the key cannot invisibly re-arm a mode the
+    /// reader is not looking at.
+    pub fn toggle_metering(&mut self) {
+        if self.tab != Tab::Usage {
+            return;
+        }
+        self.metering_view = !self.metering_view;
+        self.status_line = Some(
+            if self.metering_view {
+                "metering windows"
+            } else {
+                "tokens"
+            }
+            .to_string(),
+        );
+    }
+
+    /// The plan's own meter, grouped by day, oldest first.
+    ///
+    /// Computed on read rather than cached in `rebuild`: a fortnight of
+    /// samples yields a few dozen windows, which is nothing next to the
+    /// ledger walks the cache exists for.
+    pub fn metering_days(&self) -> Vec<MeterDay> {
+        let mut by_day: BTreeMap<String, Vec<u64>> = BTreeMap::new();
+        for window in &self.scan.metering.windows {
+            by_day
+                .entry(window.day.clone())
+                .or_default()
+                .push(window.peak);
+        }
+        by_day
+            .into_iter()
+            .map(|(day, peaks)| MeterDay {
+                windows: peaks.len(),
+                avg_peak: (peaks.iter().sum::<u64>() as f64 / peaks.len() as f64).round() as u64,
+                max_peak: peaks.iter().copied().max().unwrap_or(0),
+                day,
+            })
+            .collect()
     }
 
     pub fn cycle_granularity(&mut self) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,14 @@ pub struct UsageConfig {
     pub scan: bool,
     /// How many days of daily totals to retain and report.
     pub window_days: u64,
+    /// Project rows to fold into another, `shown name -> fold into`.
+    ///
+    /// The same project legitimately earns two names: a checkout with an
+    /// `origin` remote reports `owner/name`, a copy of the same code with no
+    /// remote reports its folder basename. surface never guesses that two
+    /// names are one project — that would misattribute someone's spend on a
+    /// string resemblance — so the operator declares it here instead.
+    pub repo_aliases: BTreeMap<String, String>,
 }
 
 impl Default for UsageConfig {
@@ -99,6 +107,7 @@ impl Default for UsageConfig {
         Self {
             scan: true,
             window_days: DEFAULT_USAGE_WINDOW_DAYS,
+            repo_aliases: BTreeMap::new(),
         }
     }
 }
@@ -194,6 +203,7 @@ mod tests {
             usage: UsageConfig {
                 scan: true,
                 window_days: 0,
+                ..Default::default()
             },
             ..Config::default()
         };

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -28,6 +28,7 @@
 use chrono::{Datelike, Duration, Utc, Weekday};
 
 use crate::ledger::{Ledger, Tokens};
+use crate::scan::meter;
 #[cfg(feature = "sqlite")]
 use crate::scan::sites;
 use crate::scan::{tooling, usage, Scan, Timings};
@@ -51,6 +52,7 @@ pub fn scan() -> (Scan, Timings) {
             #[cfg(feature = "sqlite")]
             sites: sites(),
             usage: usage(),
+            metering: metering(),
             failed: Vec::new(),
             demo: true,
         },
@@ -206,6 +208,36 @@ fn sites() -> sites::Sites {
         }],
         blind_spots: Vec::new(),
         disabled: false,
+    }
+}
+
+// ----------------------------------------------------------------- metering
+
+/// Fourteen days of 5-hour windows: mostly shallow, two hot days, one brush
+/// with the cap — the states a viewer needs to see, none of them invented
+/// past what a real fortnight looks like.
+fn metering() -> meter::Metering {
+    let mut rng = Rng(SEED ^ 0x11E7E4);
+    let today = Utc::now().date_naive();
+    let mut windows = Vec::new();
+    for days_ago in (0..14).rev() {
+        let day = (today - Duration::days(days_ago)).format("%Y-%m-%d");
+        for _ in 0..rng.range(1, 3) {
+            let peak = match rng.range(1, 6) {
+                1 => rng.range(45, 92), // a hot window
+                _ => rng.range(2, 35),  // an ordinary one
+            };
+            windows.push(meter::MeterWindow {
+                day: day.to_string(),
+                peak,
+            });
+        }
+    }
+    meter::Metering {
+        from: windows.first().map(|w| w.day.clone()),
+        to: windows.last().map(|w| w.day.clone()),
+        windows,
+        found: true,
     }
 }
 

--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -132,6 +132,13 @@ pub struct Ledger {
     pub days: BTreeMap<String, DayState>,
     /// session key -> what that session is. Survives between scans.
     pub session_meta: BTreeMap<String, SessionMeta>,
+    /// Project rows folded into another at *read* time, from
+    /// `[usage.repo_aliases]`. Never persisted and never applied to the
+    /// stored keys — like prices, aliasing is a read-time operation, so
+    /// editing an alias regroups the whole history retroactively and a wrong
+    /// one is an edit away from undone.
+    #[serde(skip)]
+    pub aliases: BTreeMap<String, String>,
     /// Whether titles were being collected when this ledger was written.
     pub titles_enabled: bool,
     /// Cumulative counters, reported so a consumer can see dedup ran.
@@ -147,6 +154,7 @@ impl Default for Ledger {
             sessions: BTreeMap::new(),
             days: BTreeMap::new(),
             session_meta: BTreeMap::new(),
+            aliases: BTreeMap::new(),
             titles_enabled: false,
             duplicates_skipped: 0,
             undedupable_records: 0,
@@ -343,12 +351,30 @@ impl Ledger {
         totals
     }
 
+    /// Install the read-time aliases. Called once per scan, from config.
+    pub fn set_aliases(&mut self, aliases: BTreeMap<String, String>) {
+        self.aliases = aliases;
+    }
+
+    /// The name a project is shown under: its alias target, or itself.
+    ///
+    /// One hop, deliberately — an alias pointing at another alias does not
+    /// chase, so a cycle in the config cannot loop a scan.
+    pub fn canonical<'a>(&'a self, project: &'a str) -> &'a str {
+        self.aliases
+            .get(project)
+            .map(String::as_str)
+            .unwrap_or(project)
+    }
+
     /// Window totals per repository and model, for pricing in the viewers.
     pub fn by_project(&self) -> BTreeMap<String, BTreeMap<String, Tokens>> {
         let mut totals: BTreeMap<String, BTreeMap<String, Tokens>> = BTreeMap::new();
         for state in self.days.values() {
             for (project, models) in &state.projects {
-                let entry = totals.entry(project.clone()).or_default();
+                let entry = totals
+                    .entry(self.canonical(project).to_string())
+                    .or_default();
                 for (model, tokens) in models {
                     entry.entry(model.clone()).or_default().add(tokens);
                 }
@@ -368,7 +394,12 @@ impl Ledger {
             for (project, models) in &state.projects {
                 for (model, tokens) in models {
                     if !tokens.is_empty() {
-                        rows.push((day.clone(), project.clone(), model.clone(), *tokens));
+                        rows.push((
+                            day.clone(),
+                            self.canonical(project).to_string(),
+                            model.clone(),
+                            *tokens,
+                        ));
                     }
                 }
             }
@@ -752,6 +783,57 @@ mod tests {
         assert_eq!(
             loaded.plan(Path::new("/tmp/a.jsonl"), 10, 20),
             ReadPlan::Skip
+        );
+    }
+
+    #[test]
+    fn an_alias_folds_two_names_into_one_project() {
+        let mut ledger = Ledger::default();
+        let t = tokens(100, 10);
+        ledger.add_project("2026-07-26", "HAI Neo", "claude-opus-5", &t);
+        ledger.add_project("2026-07-27", "holistic-ai/hai-neo", "claude-opus-5", &t);
+        ledger.set_aliases(BTreeMap::from([(
+            "HAI Neo".to_string(),
+            "holistic-ai/hai-neo".to_string(),
+        )]));
+
+        let by_project = ledger.by_project();
+        assert_eq!(by_project.len(), 1, "two names, one project");
+        assert_eq!(
+            by_project["holistic-ai/hai-neo"]["claude-opus-5"].input, 200,
+            "both days' tokens under the one row"
+        );
+        assert!(
+            ledger
+                .project_rows()
+                .iter()
+                .all(|(_, project, _, _)| project == "holistic-ai/hai-neo"),
+            "the daily rows follow the alias too"
+        );
+    }
+
+    /// The stored keys stay raw: aliasing is a read-time operation, so a
+    /// changed alias regroups history and a removed one restores it.
+    #[test]
+    fn aliases_are_never_persisted_and_never_chase() {
+        let dir = temp_dir("aliases");
+        let path = ledger_path(&dir);
+        let mut ledger = Ledger::default();
+        ledger.add_project("2026-07-26", "HAI Neo", "claude-opus-5", &tokens(100, 10));
+        ledger.set_aliases(BTreeMap::from([
+            ("HAI Neo".to_string(), "middle".to_string()),
+            ("middle".to_string(), "elsewhere".to_string()),
+        ]));
+        ledger.save(&path).unwrap();
+
+        // One hop only: a chain (or a cycle) in the config cannot loop.
+        assert_eq!(ledger.canonical("HAI Neo"), "middle");
+
+        let loaded = Ledger::load(&path);
+        assert!(loaded.aliases.is_empty(), "read-time state, not persisted");
+        assert!(
+            loaded.days["2026-07-26"].projects.contains_key("HAI Neo"),
+            "the stored key is the raw one"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,7 @@ fn handle_key(app: &mut App, key: event::KeyEvent) {
         KeyCode::Char('w') => app.cycle_granularity(),
         KeyCode::Char('d') => app.toggle_detail(),
         KeyCode::Char('u') => app.toggle_unit(),
+        KeyCode::Char('m') => app.toggle_metering(),
         KeyCode::Enter => app.toggle_focus(),
         KeyCode::Char('[') => app.move_bucket(1),
         KeyCode::Char(']') => app.move_bucket(-1),

--- a/src/scan/meter.rs
+++ b/src/scan/meter.rs
@@ -1,0 +1,272 @@
+//! Claude's 5-hour metering windows, from the usage history Claude Desktop
+//! already keeps beside its config.
+//!
+//! Plans are metered in two units: how *deep* each 5-hour window runs, and how
+//! *many* windows get started. The Usage view's token table answers neither —
+//! tokens say nothing about where the plan's own meter stands. Claude Desktop
+//! samples that meter every few minutes into `plan-usage-history.json`
+//! (`{t, org, u: {fh, sd}}`: epoch millis, org id, and the 5-hour / 7-day
+//! window utilisation as percentages), which is enough to reconstruct each
+//! window and the peak it reached.
+//!
+//! # What is read, and what is not
+//!
+//! Timestamps and two percentages. The org id in each sample is not kept,
+//! shown, or written anywhere — the file is parsed for `t` and `u.fh` only.
+//! Absent file (no Claude Desktop, or another platform layout) scans to an
+//! empty result and the view says so, rather than rendering a zero that would
+//! read as "no usage".
+//!
+//! # Windows are reconstructed, not reported
+//!
+//! The file stores samples, not windows. A window is inferred to start when
+//! utilisation rises from zero, resumes after a gap of at least the window
+//! length, or falls sharply (a reset while the app kept sampling). Samples
+//! only exist while Claude Desktop runs, so the count is a floor — windows
+//! started while it was closed are invisible — which is the honest direction
+//! for a "how close to the cap am I" signal to err.
+
+use std::path::{Path, PathBuf};
+
+/// The 5-hour window length, for gap detection, in milliseconds.
+const WINDOW_MS: i64 = 5 * 60 * 60 * 1000;
+
+/// A drop this many percentage points (while sampling stayed continuous) is a
+/// meter reset, not noise: utilisation only decays with time, and a decay
+/// this steep inside one sampling gap means a new window began.
+const RESET_DROP: u64 = 30;
+
+/// One reconstructed 5-hour window.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeterWindow {
+    /// `YYYY-MM-DD` (UTC) the window started.
+    pub day: String,
+    /// Highest utilisation the window reached, in percent.
+    pub peak: u64,
+}
+
+/// Every window the history file can testify to.
+#[derive(Debug, Clone, Default)]
+pub struct Metering {
+    pub windows: Vec<MeterWindow>,
+    /// First and last sample days, so the view can say what span the count
+    /// covers rather than implying it covers the usage window.
+    pub from: Option<String>,
+    pub to: Option<String>,
+    /// The history file was found and parsed. `false` renders as an honest
+    /// absence, never as zero windows.
+    pub found: bool,
+}
+
+impl Metering {
+    /// Peak utilisation across every window, in percent.
+    pub fn hottest(&self) -> u64 {
+        self.windows.iter().map(|w| w.peak).max().unwrap_or(0)
+    }
+
+    /// Mean of the per-window peaks, in percent.
+    pub fn average_peak(&self) -> u64 {
+        if self.windows.is_empty() {
+            return 0;
+        }
+        let sum: u64 = self.windows.iter().map(|w| w.peak).sum();
+        (sum as f64 / self.windows.len() as f64).round() as u64
+    }
+}
+
+/// Read the metering history this machine has, if any.
+pub fn scan() -> Metering {
+    let Some(home) = crate::paths::home() else {
+        return Metering::default();
+    };
+    candidates(&home)
+        .iter()
+        .find(|p| p.is_file())
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|raw| parse(&raw))
+        .unwrap_or_default()
+}
+
+/// Where Claude Desktop keeps the file, per platform. Checked in order.
+fn candidates(home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join("AppData/Roaming/Claude/plan-usage-history.json"),
+        home.join("Library/Application Support/Claude/plan-usage-history.json"),
+        home.join(".config/Claude/plan-usage-history.json"),
+    ]
+}
+
+/// One sample: when, and how used the 5-hour window was.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Sample {
+    /// Epoch milliseconds.
+    t: i64,
+    /// 5-hour window utilisation, percent.
+    fh: u64,
+}
+
+/// Parse the history file into windows.
+pub fn parse(raw: &str) -> Option<Metering> {
+    let value: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let samples: Vec<Sample> = value
+        .get("samples")?
+        .as_array()?
+        .iter()
+        .filter_map(|s| {
+            Some(Sample {
+                t: s.get("t")?.as_i64()?,
+                fh: s.get("u")?.get("fh")?.as_u64()?,
+            })
+        })
+        .collect();
+    if samples.is_empty() {
+        return None;
+    }
+
+    Some(Metering {
+        windows: windows_of(&samples),
+        from: Some(day_of(samples.first()?.t)),
+        to: Some(day_of(samples.last()?.t)),
+        found: true,
+    })
+}
+
+/// Reconstruct windows from the sample stream. See the module doc for the
+/// three start conditions; the peak is simply the highest sample inside.
+fn windows_of(samples: &[Sample]) -> Vec<MeterWindow> {
+    let mut windows: Vec<MeterWindow> = Vec::new();
+    let mut current: Option<MeterWindow> = None;
+    let mut prev: Option<Sample> = None;
+
+    for &sample in samples {
+        let starts = match prev {
+            None => sample.fh > 0,
+            Some(prev) => {
+                sample.fh > 0
+                    && (prev.fh == 0
+                        || sample.t - prev.t >= WINDOW_MS
+                        || sample.fh + RESET_DROP < prev.fh)
+            }
+        };
+        if starts {
+            windows.extend(current.take());
+            current = Some(MeterWindow {
+                day: day_of(sample.t),
+                peak: sample.fh,
+            });
+        } else if let Some(window) = &mut current {
+            window.peak = window.peak.max(sample.fh);
+        }
+        prev = Some(sample);
+    }
+    windows.extend(current);
+    windows
+}
+
+/// `YYYY-MM-DD` in UTC from epoch milliseconds.
+fn day_of(millis: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(millis)
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Minutes to epoch millis, from an arbitrary but fixed origin.
+    fn at(minutes: i64) -> i64 {
+        1_753_920_000_000 + minutes * 60_000
+    }
+
+    fn history(samples: &[(i64, u64)]) -> String {
+        json!({
+            "version": 2,
+            "samples": samples.iter().map(|(t, fh)| json!({
+                "t": t, "org": "not-kept", "u": {"fh": fh, "sd": 1}
+            })).collect::<Vec<_>>()
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn a_rise_from_zero_starts_a_window_and_its_peak_is_kept() {
+        let raw = history(&[
+            (at(0), 0),
+            (at(5), 12),
+            (at(10), 40),
+            (at(15), 33), // decay inside the same window
+        ]);
+        let m = parse(&raw).unwrap();
+        assert!(m.found);
+        assert_eq!(m.windows.len(), 1);
+        assert_eq!(m.windows[0].peak, 40);
+    }
+
+    #[test]
+    fn a_sharp_drop_is_a_reset_and_a_shallow_one_is_decay() {
+        let raw = history(&[
+            (at(0), 50),
+            (at(5), 55),
+            (at(10), 15), // 40-point drop: a new window
+            (at(15), 35), // 20-point rise: same window
+        ]);
+        let m = parse(&raw).unwrap();
+        assert_eq!(m.windows.len(), 2);
+        assert_eq!(m.windows[0].peak, 55);
+        assert_eq!(m.windows[1].peak, 35);
+    }
+
+    #[test]
+    fn a_gap_of_a_window_length_starts_a_new_window() {
+        let raw = history(&[
+            (at(0), 20),
+            (at(5), 25),
+            (at(5 + 5 * 60), 10), // five hours later
+        ]);
+        let m = parse(&raw).unwrap();
+        assert_eq!(m.windows.len(), 2);
+    }
+
+    #[test]
+    fn idle_samples_start_nothing() {
+        let raw = history(&[(at(0), 0), (at(5), 0), (at(10), 0)]);
+        let m = parse(&raw).unwrap();
+        assert!(m.windows.is_empty());
+        assert_eq!(m.hottest(), 0);
+    }
+
+    #[test]
+    fn summary_figures_average_the_peaks_not_the_samples() {
+        let raw = history(&[
+            (at(0), 10),
+            (at(5), 60), // window 1 peaks at 60
+            (at(10), 2), // a 58-point drop: reset, window 2
+            (at(15), 40),
+        ]);
+        let m = parse(&raw).unwrap();
+        assert_eq!(m.windows.len(), 2);
+        assert_eq!(m.average_peak(), 50, "(60 + 40) / 2");
+        assert_eq!(m.hottest(), 60);
+    }
+
+    #[test]
+    fn an_absent_or_malformed_file_is_not_found_rather_than_zero() {
+        assert!(parse("{not json").is_none());
+        assert!(parse(r#"{"version": 2, "samples": []}"#).is_none());
+        let m = Metering::default();
+        assert!(!m.found, "absence must be distinguishable from idleness");
+    }
+
+    #[test]
+    fn the_org_id_is_never_kept() {
+        let raw = history(&[(at(0), 10)]);
+        let m = parse(&raw).unwrap();
+        let rendered = format!("{m:?}");
+        assert!(
+            !rendered.contains("not-kept"),
+            "org id leaked into the result"
+        );
+    }
+}

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -12,6 +12,7 @@
 //! release profile deliberately does not set `panic = "abort"`.
 
 pub mod apps;
+pub mod meter;
 #[cfg(feature = "sqlite")]
 pub mod sites;
 pub mod tooling;
@@ -32,6 +33,8 @@ pub struct Scan {
     #[cfg(feature = "sqlite")]
     pub sites: sites::Sites,
     pub usage: usage::Usage,
+    /// Claude's 5-hour metering windows, from Claude Desktop's own samples.
+    pub metering: meter::Metering,
     /// Sections that panicked, by name. Empty is the normal case.
     pub failed: Vec<&'static str>,
     /// Built by [`crate::demo`] rather than read off this machine. Never true
@@ -85,6 +88,9 @@ pub fn run(config: &Config, state_dir: &Path) -> (Scan, Timings) {
     .unwrap_or_default();
     timings.usage_ms = mark.elapsed().as_millis();
 
+    // One small file, read whole; not worth a timing of its own.
+    let metering = section("metering", &mut failed, meter::scan).unwrap_or_default();
+
     timings.total_ms = started.elapsed().as_millis();
 
     (
@@ -94,6 +100,7 @@ pub fn run(config: &Config, state_dir: &Path) -> (Scan, Timings) {
             #[cfg(feature = "sqlite")]
             sites,
             usage,
+            metering,
             failed,
             demo: false,
         },

--- a/src/scan/usage.rs
+++ b/src/scan/usage.rs
@@ -138,6 +138,9 @@ pub fn scan(config: &UsageConfig, state_dir: &Path) -> Usage {
     // still matters: a ledger inherited from a tool that did collect them has to
     // drop them rather than keep showing stale ones.
     ledger.sync_title_policy(false);
+    // Read-time state, not persisted: the stored keys stay raw, so an edited
+    // alias regroups the whole window on the next run.
+    ledger.set_aliases(config.repo_aliases.clone());
 
     let mut usage = Usage {
         window_days: config.window_days,

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -781,6 +781,110 @@ fn draw_tools(frame: &mut Frame, area: Rect, app: &App) -> Option<Rows> {
     row_hits(area, &table_state, 1)
 }
 
+/// The plan's own meter: 5-hour windows per day and the peak each reached.
+///
+/// This is the number the plan is actually enforced in — the token table says
+/// how much work was done, this says how close that work came to the cap. A
+/// window at 100% that keeps going is when extra usage starts billing, so the
+/// peaks here are the early warning the token counts cannot give.
+///
+/// Claude only, from Claude Desktop's own samples; a machine without them
+/// gets the absence stated, never a zero that would read as idleness. The
+/// count is a floor — samples exist only while the app runs.
+fn draw_metering(frame: &mut Frame, area: Rect, app: &App) {
+    let metering = &app.scan.metering;
+    if !metering.found {
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "No metering history on this machine.",
+                    Style::default().fg(theme::TEXT),
+                )),
+                Line::from(Span::styled(
+                    "Claude Desktop samples its plan meter into plan-usage-history.json;",
+                    Style::default().fg(theme::DIM),
+                )),
+                Line::from(Span::styled(
+                    "without it there is nothing to reconstruct. [m] returns to tokens.",
+                    Style::default().fg(theme::DIM),
+                )),
+            ])
+            .block(panel("metering windows \u{b7} [m] tokens")),
+            area,
+        );
+        return;
+    }
+
+    let days = app.metering_days();
+    let hottest = metering.hottest();
+
+    let rows: Vec<Row> = days
+        .iter()
+        .map(|d| {
+            // The bar is the day's deepest window against the cap itself —
+            // not against the hottest day — so half a bar always means half
+            // way to the meter, on every machine.
+            let bar = ((d.max_peak as f64 / 100.0) * 24.0).round() as usize;
+            let hot = d.max_peak >= 90;
+            let mark = if hot {
+                Span::styled("\u{25b2} ", Style::default().fg(theme::WARN))
+            } else {
+                Span::raw("")
+            };
+            Row::new(vec![
+                Cell::from(d.day.clone()),
+                Cell::from(thousands(d.windows as u64)),
+                Cell::from(format!("{}%", d.avg_peak)),
+                Cell::from(Line::from(vec![
+                    mark,
+                    Span::styled(
+                        format!("{}%", d.max_peak),
+                        Style::default().fg(if hot { theme::WARN } else { theme::TEXT }),
+                    ),
+                ])),
+                Cell::from(Line::from(Span::styled(
+                    "\u{2588}".repeat(bar),
+                    Style::default().fg(if hot { theme::WARN } else { theme::SEQUENTIAL }),
+                ))),
+            ])
+        })
+        .collect();
+
+    let span = match (&metering.from, &metering.to) {
+        (Some(from), Some(to)) if from != to => format!("{from} \u{2192} {to}"),
+        (Some(from), _) => from.clone(),
+        _ => String::new(),
+    };
+    let mut title = format!(
+        "claude 5-hour windows \u{b7} {} over {span} \u{b7} avg peak {}%",
+        metering.windows.len(),
+        metering.average_peak(),
+    );
+    if hottest >= 90 {
+        title.push_str(&format!(" \u{b7} \u{25b2} hottest {hottest}%"));
+    } else {
+        title.push_str(&format!(" \u{b7} hottest {hottest}%"));
+    }
+    title.push_str(" \u{b7} [m] tokens");
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(12),
+            Constraint::Length(9),
+            Constraint::Length(10),
+            Constraint::Length(10),
+            Constraint::Min(10),
+        ],
+    )
+    .header(header(&[
+        "DAY", "WINDOWS", "AVG PEAK", "MAX PEAK", "VS CAP",
+    ]))
+    .block(panel(&title));
+
+    frame.render_widget(table, area);
+}
+
 // ------------------------------------------------------------------- sites
 
 #[cfg(feature = "sqlite")]
@@ -894,6 +998,11 @@ fn draw_sites(frame: &mut Frame, area: Rect, _app: &App) -> Option<Rows> {
 // ------------------------------------------------------------------- usage
 
 fn draw_usage(frame: &mut Frame, area: Rect, app: &App) -> Option<Rows> {
+    if app.metering_view {
+        draw_metering(frame, area, app);
+        return None;
+    }
+
     let rows = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Percentage(45), Constraint::Min(6)])
@@ -1815,6 +1924,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
         Line::from("  enter           switch pane, where a view has two"),
         Line::from("  d               token detail under each row"),
         Line::from("  u               Overview chart: spend or tokens"),
+        Line::from("  m               Usage view: tokens or metering windows"),
         Line::from("  [ / \u{5d}           move the chart cursor a bucket"),
         Line::from("  backspace       drop the chart cursor"),
         Line::from("  click           a view, a table row, or a pane"),
@@ -1940,6 +2050,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2017,6 +2128,7 @@ mod tests {
             #[cfg(feature = "sqlite")]
             sites: Default::default(),
             usage: Default::default(),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2149,6 +2261,70 @@ mod tests {
         assert!(!out.contains("$0.00"));
     }
 
+    /// `m` swaps the Usage view for the plan's own meter and back, shows the
+    /// per-day peaks, and does nothing on any other view.
+    #[test]
+    fn the_usage_view_toggles_to_metering_windows() {
+        let mut app = populated();
+        app.set_tab(Tab::Overview);
+        app.toggle_metering();
+        assert!(!app.metering_view, "a no-op off the Usage view");
+
+        app.set_tab(Tab::Usage);
+        app.scan.metering = crate::scan::meter::Metering {
+            windows: vec![
+                crate::scan::meter::MeterWindow {
+                    day: "2026-07-27".to_string(),
+                    peak: 75,
+                },
+                crate::scan::meter::MeterWindow {
+                    day: "2026-07-27".to_string(),
+                    peak: 43,
+                },
+                crate::scan::meter::MeterWindow {
+                    day: "2026-07-28".to_string(),
+                    peak: 95,
+                },
+            ],
+            from: Some("2026-07-27".to_string()),
+            to: Some("2026-07-28".to_string()),
+            found: true,
+        };
+        app.toggle_metering();
+        assert!(app.metering_view);
+        assert_eq!(app.row_count(), 0, "the meter has nothing to select");
+
+        let out = rendered(&app, 150, 30);
+        assert!(out.contains("claude 5-hour windows"), "the panel title");
+        assert!(out.contains("MAX PEAK"), "the table header");
+        assert!(out.contains("2026-07-27"));
+        assert!(out.contains("59%"), "avg of 75 and 43 on the hot day");
+        assert!(
+            out.contains("\u{25b2} 95%"),
+            "90%+ is flagged, not just shown"
+        );
+        assert!(out.contains("hottest 95%"), "the title carries the summary");
+
+        app.toggle_metering();
+        assert!(!app.metering_view);
+        let out = rendered(&app, 150, 30);
+        assert!(out.contains("tokens by model"), "back to the token chart");
+    }
+
+    /// A machine without the history file states the absence — never a zero
+    /// that would read as an idle plan.
+    #[test]
+    fn missing_metering_history_is_an_absence_not_a_zero() {
+        let mut app = populated();
+        app.set_tab(Tab::Usage);
+        assert!(!app.scan.metering.found, "the fixture has no history");
+        app.toggle_metering();
+
+        let out = rendered(&app, 150, 30);
+        assert!(out.contains("No metering history on this machine."));
+        assert!(!out.contains("MAX PEAK"), "no empty table pretending");
+    }
+
     #[test]
     fn the_projects_view_lists_every_attributed_repository() {
         let mut app = populated();
@@ -2189,6 +2365,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2240,6 +2417,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2691,6 +2869,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2968,6 +3147,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -3046,6 +3226,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -3069,6 +3250,7 @@ mod tests {
             #[cfg(feature = "sqlite")]
             sites: Default::default(),
             usage: Default::default(),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2394,6 +2394,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2440,6 +2441,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -459,6 +459,10 @@ fn draw_rankings(frame: &mut Frame, area: Rect, app: &App) {
     draw_ranking(frame, columns[2], "by repository", &by_repo, app);
 }
 
+/// Money the reader pays, work the reader did, what that work would have
+/// cost, how hard the plan is being driven, and what is installed — in that
+/// order, left to right: the actual bill first, the hypothetical after the
+/// facts it is derived from, the machine's inventory last.
 fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
     let cards = Layout::default()
         .direction(Direction::Horizontal)
@@ -467,13 +471,27 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
 
     draw_spend_card(frame, cards[0], app);
 
+    card(
+        frame,
+        cards[1],
+        "tokens",
+        &theme::compact(app.total_tokens()),
+        &[
+            format!("{} messages", thousands(app.total_messages())),
+            // Distinct models, not the `(tool, model)` pairs `models()` lists: one
+            // model run by two tools was counted twice here.
+            format!("{} models", app.distinct_models()),
+        ],
+        theme::TEXT,
+    );
+
     let unpriced = app.unpriced_models();
     // A total with nothing to compare it against is the least useful shape a cost
     // figure can take, so the window line carries a projected rate and the line
     // under it says which way the spend is going. Both are dropped rather than
     // faked when they cannot be computed — a zero-day window, or too few active
     // days for a half-against-half comparison to mean anything.
-    let mut spend_detail = vec![match app.daily_rate() {
+    let mut cost_detail = vec![match app.daily_rate() {
         Some(rate) => format!(
             "over {} days \u{b7} \u{2248} {}/day",
             app.scan.usage.window_days,
@@ -491,17 +509,17 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
         } else {
             "\u{25bc}"
         };
-        spend_detail.push(format!(
+        cost_detail.push(format!(
             "{arrow} {:.0}% vs prior {} days",
             trend.change.abs() * 100.0,
             trend.days
         ));
     }
     // The figure is list-rate arithmetic, not a bill, and the card must say so:
-    // "SPEND" alone reads as money out the door, which for a subscription user
-    // it is not. With unpriced models the caveat line matters more — and `≥` on
-    // the figure plus the amber are already carrying "estimate".
-    spend_detail.push(if unpriced > 0 {
+    // "TOKEN COST" is the hypothetical beside SPEND's actual. With unpriced
+    // models the caveat line matters more — and `≥` on the figure plus the
+    // amber are already carrying "estimate".
+    cost_detail.push(if unpriced > 0 {
         format!("\u{25b2} {unpriced} model(s) unpriced")
     } else {
         "at API list rates".to_string()
@@ -509,10 +527,10 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
 
     card(
         frame,
-        cards[1],
+        cards[2],
         "token cost",
         &format_usd(app.total_usd()),
-        &spend_detail,
+        &cost_detail,
         if unpriced > 0 {
             theme::WARN
         } else {
@@ -520,67 +538,41 @@ fn draw_cards(frame: &mut Frame, area: Rect, app: &App) {
         },
     );
 
-    card(
-        frame,
-        cards[2],
-        "tokens",
-        &theme::compact(app.total_tokens()),
-        &[
-            format!("{} messages", thousands(app.total_messages())),
-            // Distinct models, not the `(tool, model)` pairs `models()` lists: one
-            // model run by two tools was counted twice here.
-            format!("{} models", app.distinct_models()),
-        ],
-        theme::TEXT,
-    );
-
-    let s = &app.scan.tools_summary;
-    card(
-        frame,
-        cards[3],
-        "tools",
-        &s.detected.to_string(),
-        &[
-            if s.autonomous > 0 {
-                format!("\u{25b2} {} autonomous", s.autonomous)
-            } else {
-                "none autonomous".to_string()
-            },
-            format!("{} vendors", s.vendors.len()),
-        ],
-        if s.autonomous > 0 {
-            theme::WARN
-        } else {
-            theme::TEXT
-        },
-    );
-
-    draw_sites_card(frame, cards[4], app);
+    draw_meter_card(frame, cards[3], app);
+    draw_tools_sites_card(frame, cards[4], app);
 }
 
-/// What the seats actually cost, as far as that can be known — against the
-/// token arithmetic on the TOKEN COST card beside it.
+/// What is actually paid: seats, and whether overflow billing is in play.
 ///
-/// Three states, in the house grammar: a configured figure is plain, a
-/// detected plan's list price is `≈` an estimate, a tool with usage but no
-/// figure makes the total `≥` a floor — and knowing nothing shows `–` and
-/// says how to fix it, never a guess.
+/// Only real money lives here — the API-rate hypothetical has its own card,
+/// TOKEN COST, and never leaks into this one. Three states, in the house
+/// grammar: a configured figure is plain, a detected plan's list price is `≈`
+/// an estimate, a tool with usage but no figure makes the total `≥` a floor —
+/// and knowing nothing shows `–` and says how to fix it, never a guess.
 fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
+    // Extra usage bills only after a metering window pegs at 100%, so the
+    // meter is the honest witness: never pegged means none, a peg means it
+    // is likely, and no meter history means nothing is claimed either way.
+    let extra_usage = |metering: &crate::scan::meter::Metering| -> Option<String> {
+        if !metering.found || metering.windows.is_empty() {
+            return None;
+        }
+        Some(if metering.hottest() >= 100 {
+            "\u{25b2} extra usage likely".to_string()
+        } else {
+            "no extra usage".to_string()
+        })
+    };
+
     let Some(estimate) = app.spend_estimate() else {
         // Card lines have ~24 columns on a 150-column terminal; every string
         // here is written to that width rather than truncated into noise.
-        card(
-            frame,
-            area,
-            "spend",
-            "\u{2013}",
-            &[
-                "no seat price known".to_string(),
-                "set [cost.subscriptions]".to_string(),
-                "see token cost".to_string(),
-            ],
-            theme::DIM,
-        );
+        let mut detail = vec![
+            "no seat price known".to_string(),
+            "set [cost.subscriptions]".to_string(),
+        ];
+        detail.extend(extra_usage(&app.scan.metering));
+        card(frame, area, "spend", "\u{2013}", &detail, theme::DIM);
         return;
     };
 
@@ -600,14 +592,7 @@ fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
         (0, d) => format!("{d} plan(s) detected"),
         (c, d) => format!("{c} configured \u{b7} {d} detected"),
     }];
-    // The comparison the Cost view makes per tool, summed: the same tools'
-    // window tokens at API rates. Signed like `SubscriptionRow::saving`.
-    let saving = estimate.api_equivalent - estimate.monthly_usd;
-    detail.push(if saving >= 0.0 {
-        format!("{} under API rates", format_usd(saving))
-    } else {
-        format!("{} over API rates", format_usd(-saving))
-    });
+    detail.extend(extra_usage(&app.scan.metering));
     if estimate.unpriced_tools > 0 {
         detail.push(format!(
             "\u{25b2} {} tool(s) unpriced",
@@ -615,13 +600,14 @@ fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
         ));
     }
 
+    let pegged = app.scan.metering.found && app.scan.metering.hottest() >= 100;
     card(
         frame,
         area,
         "spend",
         &value,
         &detail,
-        if estimate.unpriced_tools > 0 {
+        if estimate.unpriced_tools > 0 || pegged {
             theme::WARN
         } else {
             theme::MONEY
@@ -629,16 +615,68 @@ fn draw_spend_card(frame: &mut Frame, area: Rect, app: &App) {
     );
 }
 
+/// How hard the plan itself is being driven: the average peak the 5-hour
+/// metering windows reach. The number that predicts a future cap hit — and
+/// the overflow billing behind it — which no token count can.
+fn draw_meter_card(frame: &mut Frame, area: Rect, app: &App) {
+    let metering = &app.scan.metering;
+    if !metering.found || metering.windows.is_empty() {
+        card(
+            frame,
+            area,
+            "avg usage rate",
+            "\u{2013}",
+            &[
+                "no metering history".to_string(),
+                "needs Claude Desktop".to_string(),
+            ],
+            theme::DIM,
+        );
+        return;
+    }
+
+    let hottest = metering.hottest();
+    card(
+        frame,
+        area,
+        "avg usage rate",
+        &format!("{}%", metering.average_peak()),
+        &[
+            format!("{} 5-hour window(s)", metering.windows.len()),
+            if hottest >= 90 {
+                format!("\u{25b2} hottest {hottest}%")
+            } else {
+                format!("hottest {hottest}%")
+            },
+            // The per-day breakdown lives one keypress away.
+            "[m] on Usage for days".to_string(),
+        ],
+        if hottest >= 90 {
+            theme::WARN
+        } else {
+            theme::TEXT
+        },
+    );
+}
+
+/// The machine's inventory, folded into one card: what is installed, and
+/// where this machine goes. The Tools and Sites views carry the detail.
 #[cfg(feature = "sqlite")]
-fn draw_sites_card(frame: &mut Frame, area: Rect, app: &App) {
+fn draw_tools_sites_card(frame: &mut Frame, area: Rect, app: &App) {
+    let s = &app.scan.tools_summary;
     let sites = &app.scan.sites;
     let blind = sites.blind_spots.len();
     card(
         frame,
         area,
-        "AI sites",
-        &sites.sites.len().to_string(),
+        "tools & sites",
+        &format!("{} \u{b7} {}", s.detected, sites.sites.len()),
         &[
+            if s.autonomous > 0 {
+                format!("\u{25b2} {} autonomous", s.autonomous)
+            } else {
+                "none autonomous".to_string()
+            },
             format!("{} visits", thousands(sites.total_visits())),
             if blind > 0 {
                 format!("\u{25b2} {blind} browser(s) unreadable")
@@ -646,22 +684,36 @@ fn draw_sites_card(frame: &mut Frame, area: Rect, app: &App) {
                 format!("{} profile(s) read", sites.profiles_scanned)
             },
         ],
-        if blind > 0 { theme::WARN } else { theme::TEXT },
+        if s.autonomous > 0 || blind > 0 {
+            theme::WARN
+        } else {
+            theme::TEXT
+        },
     );
 }
 
 #[cfg(not(feature = "sqlite"))]
-fn draw_sites_card(frame: &mut Frame, area: Rect, _app: &App) {
+fn draw_tools_sites_card(frame: &mut Frame, area: Rect, app: &App) {
+    let s = &app.scan.tools_summary;
     card(
         frame,
         area,
-        "AI sites",
-        "\u{2013}",
+        "tools & sites",
+        &s.detected.to_string(),
         &[
-            "not compiled in".to_string(),
+            if s.autonomous > 0 {
+                format!("\u{25b2} {} autonomous", s.autonomous)
+            } else {
+                "none autonomous".to_string()
+            },
+            "sites: not compiled in".to_string(),
             "needs the sqlite feature".to_string(),
         ],
-        theme::DIM,
+        if s.autonomous > 0 {
+            theme::WARN
+        } else {
+            theme::DIM
+        },
     );
 }
 
@@ -2412,6 +2464,10 @@ mod tests {
             "the team list price, flagged an estimate"
         );
         assert!(out.contains("1 plan(s) detected"));
+        assert!(
+            !out.contains("API rates"),
+            "the hypothetical never leaks onto SPEND"
+        );
     }
 
     #[test]
@@ -2465,6 +2521,107 @@ mod tests {
             "configured is not an estimate"
         );
         assert!(out.contains("1 tool(s) unpriced"));
+        assert!(
+            !out.contains("API rates"),
+            "the hypothetical never leaks onto SPEND"
+        );
+    }
+
+    /// The SPEND card's extra-usage line follows the meter: quiet windows say
+    /// so, a pegged one flips the warning, and no history claims nothing.
+    #[test]
+    fn the_spend_card_reports_extra_usage_from_the_meter() {
+        let mut ledger = Ledger::default();
+        ledger.add("2026-07-26", "codex", "gpt-5.6", &tokens(1_000, 2_000));
+
+        let scan = Scan {
+            tools_summary: Default::default(),
+            tools: Vec::new(),
+            #[cfg(feature = "sqlite")]
+            sites: Default::default(),
+            usage: crate::scan::usage::Usage {
+                ledger,
+                window_days: 30,
+                ..Default::default()
+            },
+            metering: crate::scan::meter::Metering {
+                windows: vec![crate::scan::meter::MeterWindow {
+                    day: "2026-07-26".to_string(),
+                    peak: 45,
+                }],
+                from: Some("2026-07-26".to_string()),
+                to: Some("2026-07-26".to_string()),
+                found: true,
+            },
+            failed: Vec::new(),
+            demo: false,
+        };
+        let mut cost = CostConfig::default();
+        cost.subscriptions.insert("codex".into(), 25.0);
+        let mut app = App::new(
+            scan,
+            Timings::default(),
+            crate::pricing::Prices::default(),
+            cost,
+        );
+        app.set_tab(Tab::Overview);
+
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("no extra usage"), "quiet windows say so");
+
+        app.scan
+            .metering
+            .windows
+            .push(crate::scan::meter::MeterWindow {
+                day: "2026-07-27".to_string(),
+                peak: 100,
+            });
+        let out = rendered(&app, 150, 40);
+        assert!(
+            out.contains("\u{25b2} extra usage likely"),
+            "a pegged window flips the warning"
+        );
+    }
+
+    /// The AVG USAGE RATE card averages the window peaks, and a machine
+    /// without metering history shows the absence rather than a zero.
+    #[test]
+    fn the_avg_usage_rate_card_averages_window_peaks() {
+        let mut app = populated();
+        app.set_tab(Tab::Overview);
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("AVG USAGE RATE"), "the card exists");
+        assert!(out.contains("no metering history"), "absence, not zero");
+
+        app.scan.metering = crate::scan::meter::Metering {
+            windows: vec![
+                crate::scan::meter::MeterWindow {
+                    day: "2026-07-26".to_string(),
+                    peak: 30,
+                },
+                crate::scan::meter::MeterWindow {
+                    day: "2026-07-27".to_string(),
+                    peak: 50,
+                },
+            ],
+            from: Some("2026-07-26".to_string()),
+            to: Some("2026-07-27".to_string()),
+            found: true,
+        };
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("40%"), "(30 + 50) / 2");
+        assert!(out.contains("hottest 50%"));
+        assert!(out.contains("2 5-hour window(s)"));
+    }
+
+    /// Tools and sites share one card, in the fifth slot.
+    #[test]
+    fn tools_and_sites_share_one_card() {
+        let mut app = populated();
+        app.set_tab(Tab::Overview);
+        let out = rendered(&app, 150, 40);
+        assert!(out.contains("TOOLS & SITES"), "the folded card");
+        assert!(!out.contains("AI SITES"), "the separate card is gone");
     }
 
     /// `m` swaps the Usage view for the plan's own meter and back, shows the

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2425,6 +2425,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2149,6 +2149,66 @@ mod tests {
         assert!(!out.contains("$0.00"));
     }
 
+    /// The same project reached two ways — a remote-less scratch folder and
+    /// the real checkout — declared one project by `[usage.repo_aliases]`:
+    /// one row, both names' tokens, and the session breakdown intact.
+    #[test]
+    fn an_aliased_project_is_one_row_and_keeps_both_names_sessions() {
+        let mut ledger = Ledger {
+            titles_enabled: true,
+            ..Default::default()
+        };
+        let t = tokens(1_000, 2_000);
+        ledger.add("2026-07-26", "claude_code", "claude-opus-5", &t);
+        ledger.add_project("2026-07-26", "HAI Neo", "claude-opus-5", &t);
+        ledger.add_session("2026-07-26", "a", "claude-opus-5", &t);
+        ledger.observe_session("a", "claude_code", "HAI Neo", Some("scratch run"));
+        ledger.add("2026-07-27", "claude_code", "claude-opus-5", &t);
+        ledger.add_project("2026-07-27", "holistic-ai/hai-neo", "claude-opus-5", &t);
+        ledger.add_session("2026-07-27", "b", "claude-opus-5", &t);
+        ledger.observe_session(
+            "b",
+            "claude_code",
+            "holistic-ai/hai-neo",
+            Some("checkout run"),
+        );
+        ledger.set_aliases(std::collections::BTreeMap::from([(
+            "HAI Neo".to_string(),
+            "holistic-ai/hai-neo".to_string(),
+        )]));
+
+        let scan = Scan {
+            tools_summary: Default::default(),
+            tools: Vec::new(),
+            #[cfg(feature = "sqlite")]
+            sites: Default::default(),
+            usage: crate::scan::usage::Usage {
+                ledger,
+                window_days: 30,
+                ..Default::default()
+            },
+            failed: Vec::new(),
+            demo: false,
+        };
+        let mut app = App::new(
+            scan,
+            Timings::default(),
+            crate::pricing::Prices::default(),
+            CostConfig::default(),
+        );
+        app.set_tab(Tab::Projects);
+
+        assert_eq!(app.repos().len(), 1, "one project, not two rows");
+        let row = &app.repos()[0];
+        assert_eq!(row.repo, "holistic-ai/hai-neo");
+        assert_eq!(row.tokens, 2 * t.total(), "both names' tokens folded in");
+        assert_eq!(
+            app.sessions_in("holistic-ai/hai-neo").len(),
+            2,
+            "sessions recorded under either name attach to the one row"
+        );
+    }
+
     #[test]
     fn the_projects_view_lists_every_attributed_repository() {
         let mut app = populated();

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2263,14 +2263,14 @@ mod tests {
         .expect("a two-model table parses");
         let mut app = populated_with(all_priced);
         app.set_tab(Tab::Overview);
-        let out = rendered(&app, 120, 40);
+        let out = rendered(&app, 150, 40);
         assert!(out.contains("at API list rates"), "the qualifier line");
         assert!(!out.contains("unpriced"), "nothing is unpriced");
 
         // One of the fixture's two models is missing from this table.
         let mut app = populated_with(prices_for_a_model());
         app.set_tab(Tab::Overview);
-        let out = rendered(&app, 120, 40);
+        let out = rendered(&app, 150, 40);
         assert!(out.contains("unpriced"), "the caveat takes the line");
         assert!(!out.contains("at API list rates"), "one line, never both");
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2289,11 +2289,17 @@ mod tests {
     /// line, never both.
     #[test]
     fn the_token_cost_card_qualifies_its_dollars() {
+        // Cache rates included: the fixture's tokens carry cache reads, and a
+        // table that omits their rate is not "all priced" — it is a floor.
         let all_priced = crate::pricing::Prices::parse(
             r#"{"claude-opus-5": {"input_cost_per_token": 0.000005,
-                                  "output_cost_per_token": 0.000025},
+                                  "output_cost_per_token": 0.000025,
+                                  "cache_read_input_token_cost": 5e-7,
+                                  "cache_creation_input_token_cost": 6e-6},
                 "gpt-5.6-sol": {"input_cost_per_token": 0.000001,
-                                "output_cost_per_token": 0.000004}}"#,
+                                "output_cost_per_token": 0.000004,
+                                "cache_read_input_token_cost": 1e-7,
+                                "cache_creation_input_token_cost": 2e-6}}"#,
         )
         .expect("a two-model table parses");
         let mut app = populated_with(all_priced);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2468,6 +2468,7 @@ mod tests {
                     source: crate::scan::plans::PlanSource::Transcript,
                 },
             )]),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2515,6 +2516,7 @@ mod tests {
                 ..Default::default()
             },
             plans: Default::default(),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2565,6 +2567,7 @@ mod tests {
                     source: crate::scan::plans::PlanSource::Account,
                 },
             )]),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2605,6 +2608,7 @@ mod tests {
             sites: Default::default(),
             usage: Default::default(),
             plans: Default::default(),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2665,6 +2669,7 @@ mod tests {
                 ..Default::default()
             },
             plans: Default::default(),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };
@@ -2799,6 +2804,7 @@ mod tests {
                 ..Default::default()
             },
             plans: Default::default(),
+            metering: Default::default(),
             failed: Vec::new(),
             demo: false,
         };

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2488,6 +2488,7 @@ mod tests {
                 window_days: 30,
                 ..Default::default()
             },
+            plans: Default::default(),
             failed: Vec::new(),
             demo: false,
         };

--- a/surface.example.toml
+++ b/surface.example.toml
@@ -39,6 +39,15 @@ scan = true
 # along with their deduplication keys.
 window_days = 30
 
+# Project rows to fold into another, "shown name" = "fold into". The same
+# project legitimately earns two names — a checkout with an `origin` remote
+# reports owner/name, a copy of the same code with no remote reports its
+# folder basename — and surface never guesses that two names are one project.
+# Declare it here instead. Applied when the ledger is read, so history
+# regroups retroactively and a wrong alias is one edit away from undone.
+# [usage.repo_aliases]
+# "HAI Neo" = "holistic-ai/hai-neo"
+
 # ---------------------------------------------------------------------- cost
 #
 # surface prices tokens at API rates. If you pay a flat subscription instead,


### PR DESCRIPTION
Packs the outstanding cost-monitoring work into one branch, superseding #52, #51 and #49.

## What this adds

The Overview's card row becomes five cards that each say what kind of money they are, and the plan's own meter gets a view of its own.

| Card | Says |
|---|---|
| SPEND | Real money — seats, and whether overflow billing is in play |
| TOKENS | Counts: messages and distinct models |
| TOKEN COST | The hypothetical, at API list rates |
| AVG USAGE RATE | How hard the plan is driven — average peak across 5-hour windows |
| TOOLS & SITES | Detection counts |

The SPEND / TOKEN COST split is the point: actual money and list-rate arithmetic are different claims, and neither leaks into the other. `[m]` on Usage swaps the token table for the plan's own metering windows.

## Review it in the same chunks the stacked PRs would have given you

History is left as-is rather than rewritten, so each superseded PR is still a contiguous set of commits:

**Supersedes #52** — the card row
- `f0ed7e6` feat(ui): the Overview cards say what kind of money they are, in order
- `77938b2` fix: the spend fixtures gain the metering field

**Supersedes #51** — the metering view *(this carried your approval of Aug 3)*
- `e09f8c4` feat(usage): [m] swaps the Usage view for the plan's own meter
- `32eb523` fix: main's new fixture gains the metering field

**Supersedes #49** — repo aliases
- `54bbe87` feat(usage): [usage.repo_aliases] folds two names for one project

**Only on this branch** — integration fixes that came out of merging the three together, and exist in none of the PRs above
- `c4284a0` fix(integration): the queue's fixtures gain the metering field
- `cf88d91` fix(integration): the all-priced token-cost fixture gains cache rates
- `4ecb38a` fix(integration): the tools-column fixture gains the plans field
- `3cc6bf4` fix(integration): widen the token-cost card test for the five-card row

## Carried over from #49

@kleyt0n, your review on #49 was dismissed before it could be actioned, so restating it here rather than losing it with the PR:

> Approved. But make sure that the changes are not generalized and will not provoke any damage to perfomance.

This is **not** claimed as resolved — `[usage.repo_aliases]` is opt-in and off unless configured, but the aliasing runs inside the usage fold, so it is worth your eye on the hot path before this merges.

## Checks

Run locally on `adriano/dev`, all green:

```
cargo fmt --all --check          clean
cargo clippy --workspace --all-targets -- -D warnings    clean
cargo test --workspace           284 passed, 0 failed
```

## Note

Contains one known cosmetic defect, not yet fixed: the TOKEN COST detail line renders `over 30 days · ≈ $65.67/` — 27 characters into a 24-column card, so the `/day` unit is cut. Happy to fix it here or leave it for a follow-up, whichever you prefer.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
