### PR TITLE
fix(cost): a ChatGPT Business premium seat prices as a premium seat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ publishing empty notes.
 
 ### Fixed
 
+- **A ChatGPT Business premium seat no longer prices as a standard one.**
+  OpenAI began selling premium Business seats on 2026-08-10 at $125/month
+  against the standard $25, and `chatgpt_plan_type` reads `team` for both.
+  Nothing else in the OpenID token — nor anywhere in Codex's global state —
+  names the tier, so a premium seat was silently reported at a fifth of its
+  cost and the SPEND card was short by $100 per seat. The premium rate is now
+  in the price table as `team_premium`, and because no file on disk can reach
+  that slug, a new `[cost.plans]` entry declares the seat:
+
+  ```toml
+  [cost.plans]
+  codex = "team_premium"
+  ```
+
+  A declared plan outranks both detected sources and is still priced at list,
+  so it stays marked an estimate — unlike `[cost.subscriptions]`, which says
+  what you actually pay. `--json` reports the provenance as `configured`.
+
 - **A missing cache rate no longer bills cache tokens at a silent zero.**
   (#16) For a model whose price-table entry omits `cache_read_input_token_cost`
   or `cache_creation_input_token_cost`, those tokens were priced at zero and

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -135,6 +135,31 @@ no plan and has no entry gets no row rather than a guess. A configured figure
 always wins and is used as given; a list-price fallback is labelled `est`
 wherever it is shown.
 
+### When the tool cannot name its own seat
+
+Detection can only report what a tool writes down, and some plans are invisible
+from disk. ChatGPT Business sells **standard** seats at $25/month and
+**premium** seats at $125/month, and `~/.codex/auth.json` records
+`chatgpt_plan_type: team` for both — nothing in the token, or anywhere else
+Codex stores state, names the tier. Left alone, a premium seat is priced as a
+standard one and your spend reads five times under.
+
+Declare the seat and detection stops guessing:
+
+```toml
+[cost.plans]
+codex = "team_premium"
+```
+
+Keys are tool ids, as above; values are plan slugs. A slug here outranks both
+the account file and the transcripts, and is priced at that plan's published
+list rate — so the figure is still labelled `est`, and the plan's *name* is
+right everywhere it is shown. That is the difference from
+`[cost.subscriptions]`, which sets the dollars directly and is taken as what
+you actually pay. Use `[cost.plans]` when your plan has a list price, and
+`[cost.subscriptions]` when it does not — an enterprise agreement, say, or any
+rate that is yours rather than published.
+
 ## Environment variables
 
 Handy for a one-off run, and what the test suite uses to stay out of a real

--- a/src/config.rs
+++ b/src/config.rs
@@ -120,6 +120,19 @@ pub struct CostConfig {
     /// Overrides the built-in list-price defaults, which are estimates and go
     /// stale. Set what you actually pay and the comparison becomes real.
     pub subscriptions: BTreeMap<String, f64>,
+
+    /// The plan slug a tool is on, where the tool's own files cannot say.
+    ///
+    /// Detection reads the plan off account files and transcripts, which is
+    /// enough whenever the tool writes down what it is paying for. Sometimes
+    /// it does not: ChatGPT Business writes `team` for a standard seat and a
+    /// premium one alike, and a premium seat costs five times as much. A slug
+    /// here is taken as fact and outranks both detected sources.
+    ///
+    /// Prefer this over [`Self::subscriptions`] when the plan has a published
+    /// list price — it keeps the plan's *name* right everywhere it is shown,
+    /// where a bare dollar figure only fixes the arithmetic.
+    pub plans: BTreeMap<String, String>,
 }
 
 impl CostConfig {
@@ -160,6 +173,15 @@ pub(crate) fn list_price(plan: &str) -> Option<f64> {
         // ChatGPT: `chatgpt_plan_type`. Business (né Team) was repriced
         // 2026-04-02 from $30 to $25 monthly.
         "team" => Some(25.0),
+        // The Business *premium* seat, sold from 2026-08-10: five times the
+        // usage and no five-hour cap, at $125 monthly ($100 annual).
+        //
+        // Nothing on this disk distinguishes it. `chatgpt_plan_type` reads
+        // `team` for both seat types, and no other claim in the token — nor
+        // anything in Codex's global state — names the tier. So detection
+        // cannot reach this slug and must not guess it: it is priceable only
+        // once `[cost.plans]` declares the seat.
+        "team_premium" => Some(125.0),
         _ => None,
     }
 }
@@ -267,5 +289,31 @@ mod tests {
         let cost = CostConfig::default();
         assert_eq!(cost.monthly("claude_code", Some("enterprise")), None);
         assert_eq!(cost.monthly("claude_code", None), None);
+    }
+
+    #[test]
+    fn a_business_premium_seat_prices_five_times_a_standard_one() {
+        // Both seats report `chatgpt_plan_type: team`; only a declared slug
+        // separates $125 from $25. Pricing them the same is the bug.
+        let cost = CostConfig::default();
+        assert_eq!(cost.monthly("codex", Some("team")), Some((25.0, true)));
+        assert_eq!(
+            cost.monthly("codex", Some("team_premium")),
+            Some((125.0, true))
+        );
+    }
+
+    #[test]
+    fn a_declared_plan_is_still_a_list_price_and_says_so() {
+        // `[cost.plans]` names the seat; it does not claim to know the
+        // invoice. The figure stays flagged an estimate, unlike
+        // `[cost.subscriptions]`, which is what was actually paid.
+        let cost = CostConfig::default();
+        let (usd, estimated) = cost.monthly("codex", Some("team_premium")).unwrap();
+        assert_eq!(usd, 125.0);
+        assert!(
+            estimated,
+            "a list price is an estimate whoever named the plan"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,6 +388,7 @@ fn print_json(scan: &scan::Scan, timings: &scan::Timings, prices: &pricing::Pric
                         "source": match p.source {
                             crate::scan::plans::PlanSource::Account => "account",
                             crate::scan::plans::PlanSource::Transcript => "transcript",
+                            crate::scan::plans::PlanSource::Configured => "configured",
                         },
                     })),
                 "evidence": d.evidence,

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -96,6 +96,7 @@ pub fn run(config: &Config, state_dir: &Path) -> (Scan, Timings) {
     // A few small file reads; neither worth a timing of its own.
     let mut plans = section("plans", &mut failed, plans::scan).unwrap_or_default();
     plans::merge_transcripts(&mut plans, &usage.ledger.plans);
+    plans::apply_overrides(&mut plans, &config.cost.plans);
     let metering = section("metering", &mut failed, meter::scan).unwrap_or_default();
 
     timings.total_ms = started.elapsed().as_millis();

--- a/src/scan/plans.rs
+++ b/src/scan/plans.rs
@@ -21,6 +21,13 @@
 //! account file names the plan the tool is signed into *now*, and exists even
 //! for a tool that has not run in the window. Where both speak, the account
 //! file wins — see the merge in [`crate::scan::run`].
+//!
+//! # Where neither can speak
+//!
+//! Some plans are invisible from here. ChatGPT Business sells standard and
+//! premium seats that differ five-fold in price and identically in every file
+//! this module can read. [`apply_overrides`] is the way out: a `[cost.plans]`
+//! entry states the seat, and is trusted over anything detected.
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -32,6 +39,9 @@ pub enum PlanSource {
     Account,
     /// A transcript record: what it was on when it last wrote usage.
     Transcript,
+    /// A `[cost.plans]` entry: what the operator says the seat is, for a plan
+    /// the tool does not write down.
+    Configured,
 }
 
 /// One tool's detected plan.
@@ -82,6 +92,40 @@ pub fn merge_transcripts(
             plan: plan.clone(),
             source: PlanSource::Transcript,
         });
+    }
+}
+
+/// Overlay the plans declared in `[cost.plans]`.
+///
+/// Config outranks both detected sources, because it is the only source for a
+/// seat the tool never describes. ChatGPT Business is the case that forces
+/// this: `chatgpt_plan_type` reads `team` for a standard seat and for a
+/// premium one, and the premium seat costs $125 against the standard $25. No
+/// other claim in the token names the tier, so pricing what detection found
+/// would under-report a real premium seat five-fold — the same failure the
+/// Claude seat lookup above exists to avoid, minus the field that made it
+/// fixable there.
+///
+/// Keys are accepted in either spelling, since `[cost.subscriptions]` next to
+/// it takes the usage id and the tool table uses the detection one.
+pub fn apply_overrides(
+    plans: &mut BTreeMap<String, DetectedPlan>,
+    overrides: &BTreeMap<String, String>,
+) {
+    for (tool, plan) in overrides {
+        let plan = plan.trim();
+        // An empty slug is a half-finished config line, not an instruction to
+        // forget what was detected.
+        if plan.is_empty() {
+            continue;
+        }
+        plans.insert(
+            usage_tool_id(tool).to_string(),
+            DetectedPlan {
+                plan: plan.to_string(),
+                source: PlanSource::Configured,
+            },
+        );
     }
 }
 
@@ -308,5 +352,63 @@ mod tests {
         assert_eq!(plans["codex"].source, PlanSource::Account);
         assert_eq!(plans["claude_code"].plan, "max_5x", "gap filled");
         assert_eq!(plans["claude_code"].source, PlanSource::Transcript);
+    }
+
+    #[test]
+    fn a_declared_plan_outranks_the_account_file_that_cannot_see_the_seat() {
+        // The premium Business seat this exists for: the token says `team`
+        // and is not lying, it simply cannot express the tier.
+        let mut plans = BTreeMap::from([(
+            "codex".to_string(),
+            DetectedPlan {
+                plan: "team".to_string(),
+                source: PlanSource::Account,
+            },
+        )]);
+
+        apply_overrides(
+            &mut plans,
+            &BTreeMap::from([("codex".to_string(), "team_premium".to_string())]),
+        );
+
+        assert_eq!(plans["codex"].plan, "team_premium");
+        assert_eq!(plans["codex"].source, PlanSource::Configured);
+    }
+
+    #[test]
+    fn a_declared_plan_is_accepted_under_either_tool_spelling() {
+        // `[cost.subscriptions]` is keyed the usage way and the tool table
+        // the detection way; a config that mixes them should still land.
+        let mut plans = BTreeMap::new();
+        apply_overrides(
+            &mut plans,
+            &BTreeMap::from([("openai_codex".to_string(), "team_premium".to_string())]),
+        );
+
+        assert_eq!(plans["codex"].plan, "team_premium");
+        assert!(
+            !plans.contains_key("openai_codex"),
+            "normalised, not doubled"
+        );
+    }
+
+    #[test]
+    fn an_empty_declared_slug_leaves_detection_alone() {
+        // A half-written config line should not erase a real detection.
+        let mut plans = BTreeMap::from([(
+            "codex".to_string(),
+            DetectedPlan {
+                plan: "team".to_string(),
+                source: PlanSource::Account,
+            },
+        )]);
+
+        apply_overrides(
+            &mut plans,
+            &BTreeMap::from([("codex".to_string(), "   ".to_string())]),
+        );
+
+        assert_eq!(plans["codex"].plan, "team");
+        assert_eq!(plans["codex"].source, PlanSource::Account);
     }
 }

--- a/surface.example.toml
+++ b/surface.example.toml
@@ -65,6 +65,20 @@ window_days = 30
 # claude_code = 100.0
 # codex = 30.0
 
+# The plan a tool is on, where the tool's own files cannot say. Values are plan
+# slugs; a slug here outranks both the account file and the transcripts, and is
+# priced at that plan's list rate — so it stays marked an estimate, while the
+# plan's name comes out right everywhere it is shown.
+#
+# ChatGPT Business is why this exists: standard seats are $25/month and premium
+# seats $125, and chatgpt_plan_type reads `team` for both. Nothing on disk tells
+# them apart, so a premium seat prices as a standard one until declared here.
+#
+# Use [cost.subscriptions] instead when the rate is yours rather than published
+# — an enterprise agreement, say. It wins over anything set here.
+[cost.plans]
+# codex = "team_premium"
+
 # ------------------------------------------------------------ env overrides
 #
 # Environment variables win over this file, and are handy for one-off runs:


### PR DESCRIPTION
## What

OpenAI began selling **premium** ChatGPT Business seats on 2026-08-10: $125/month against the standard $25 (annual $100 vs $20), for 5× usage and no five-hour cap. surface priced every Business seat at $25, so a premium seat was reported at a fifth of its cost.

## Why it can't be detected

`~/.codex/auth.json` records `chatgpt_plan_type: "team"` for **both** seat types. I checked the rest of the token — `organizations` carries only `id`/`is_default`/`role`/`title`, and an 874 KB `.codex-global-state.json` has no `plan`, `seat`, `tier`, `premium`, `subscription`, `entitlement` or `quota` key anywhere. Nothing on disk distinguishes the tiers.

This is the same failure [`claude_seat`](../blob/main/src/scan/plans.rs) already guards against — a Team premium seat whose `seatTier` reads `team_tier_1` like a standard one, rescued by `userRateLimitTier` naming the capacity. ChatGPT has no equivalent field, so detection can't be taught to see it, and per this codebase's rule an unknown plan must not be guessed.

## What this does

- `list_price` gains `team_premium` → `125.0`, the published monthly rate.
- New `[cost.plans]` map declares a tool's plan slug where the tool can't:

  ```toml
  [cost.plans]
  codex = "team_premium"
  ```

- A declared plan outranks the account file and transcripts, and is accepted under either tool spelling (`codex` or `openai_codex`). An empty slug is ignored rather than erasing a detection.
- Still priced at list, so it stays flagged an estimate. `[cost.subscriptions]` continues to win over both — it states what is actually paid.
- `--json` reports the provenance as `configured`.

## Verification

289 tests pass; `cargo fmt --check` and `cargo clippy --all-targets` clean. Six new tests cover the price, the precedence, the id normalisation and the empty-slug case.

End to end on a real machine, the SPEND card moves as intended:

```
before   $125.00/mo  ·  2 configured seat(s)
after   ≈$225.00/mo  ·  2 plan(s) detected
```

## Note for reviewers

`[cost.subscriptions]` outranks `[cost.plans]` by design, so anyone who already pinned a dollar figure for `codex` sees no change until they raise that figure or drop the line. That's correct — an explicit "this is what I pay" should beat a list-price estimate — but it does mean this fix is silent for the hand-configured case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
