### PR TITLE
feat(tools): surface sees Grok Bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,25 @@ publishing empty notes.
 
 ## [Unreleased]
 
+### Added
+
+- **Grok Bot is detected.** xAI's desktop agent joins the tool table as an
+  autonomous agent, found by `~/.grokbot`, its process, its executable or its
+  installed application name. It ships a local-exec daemon, speaks MCP and can
+  hold an egress tunnel open, so it is an agent that acts on this machine
+  rather than a chat window — and it counts toward the autonomous total on the
+  Overview. Detection only: `~/.grokbot` holds daemon state and settings, no
+  transcripts, so Grok Bot contributes no tokens or cost, the same as the other
+  desktop tools. `grok.com` and `x.ai` were already covered as domains.
+
 ### Fixed
+
+- **A Windows DisplayName ending in a version now matches.** Installed
+  applications were matched exactly, with an allowance for `Cursor (User)` and
+  dashed qualifiers, so `Grok Bot 0.44.0` failed the one channel that can see a
+  GUI tool which has never been launched. A trailing version — digits and dots
+  to the end of the string, and nothing else — is now accepted, which keeps
+  `Claude` from claiming a hypothetical `Claude 3 Desktop`.
 
 - **A missing cache rate no longer bills cache tokens at a silent zero.**
   (#16) For a model whose price-table entry omits `cache_read_input_token_cost`

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ looked for.
 
 | | Where it looks | What it records |
 |---|---|---|
-| **Tools** | `PATH`, config directories, editor extensions, running processes, installed apps | Which of 18 AI tools are present, and which can execute code on your machine |
+| **Tools** | `PATH`, config directories, editor extensions, running processes, installed apps | Which of 19 AI tools are present, and which can execute code on your machine |
 | **Sites** | Browser history for 10 browsers (Chromium and Firefox families) | Visit counts for 30 known AI domains — domain, count, last-seen date, nothing else |
 | **Usage** | Transcripts Claude Code, Codex and OpenCode already write | Tokens per day, tool and model, attributed to the git repo the work happened in |
 | **Cost** | LiteLLM's public price table | The above, priced — plus a subscription comparison if you configure one |
@@ -101,12 +101,12 @@ The first run reads every transcript, which on a large corpus takes a while.
 Every run after it reads only the bytes that were appended — typically under a
 second.
 
-### The 18 tools it recognises
+### The 19 tools it recognises
 
 **Can act** means the tool can execute code or take actions on this machine on a
 model's behalf — the one judgement surface makes. **Tokens** means it also writes
 a transcript surface can read, so it contributes usage and cost rows; the other
-fifteen are detected but contribute no numbers, because they write nothing
+sixteen are detected but contribute no numbers, because they write nothing
 readable.
 
 | | Tool | Vendor | Kind | Can act | Tokens |
@@ -115,6 +115,7 @@ readable.
 | <img src="https://raw.githubusercontent.com/holistic-ai/surface/main/docs/assets/tools/claude_desktop.png" alt="" width="22" height="22"> | **Claude Desktop** | Anthropic | assistant |  |  |
 | <img src="https://raw.githubusercontent.com/holistic-ai/surface/main/docs/assets/tools/openai_codex.png" alt="" width="22" height="22"> | **Codex CLI** | OpenAI | coding agent | ✅ | ✅ |
 | <img src="https://raw.githubusercontent.com/holistic-ai/surface/main/docs/assets/tools/chatgpt_desktop.png" alt="" width="22" height="22"> | **ChatGPT Desktop** | OpenAI | assistant |  |  |
+|  | **Grok Bot** | xAI | autonomous agent | ✅ |  |
 | <img src="https://raw.githubusercontent.com/holistic-ai/surface/main/docs/assets/tools/opencode.png" alt="" width="22" height="22"> | **OpenCode** | SST | coding agent | ✅ | ✅ |
 | <img src="https://raw.githubusercontent.com/holistic-ai/surface/main/docs/assets/tools/openclaw.png" alt="" width="22" height="22"> | **OpenClaw** | OpenClaw | autonomous agent | ✅ |  |
 | <img src="https://raw.githubusercontent.com/holistic-ai/surface/main/docs/assets/tools/cursor.png" alt="" width="22" height="22"> | **Cursor** | Anysphere | editor | ✅ |  |

--- a/docs/assets/tools/SOURCES.md
+++ b/docs/assets/tools/SOURCES.md
@@ -9,12 +9,18 @@ owner and is used here only to identify the tool surface detects.
 Regenerate with the script in the pull request that added them; refresh a
 single logo by re-fetching its URL and re-running the same chip step.
 
+`grok_bot.png` is listed above but not yet drawn: its row in the tool tables
+renders without a mark until someone runs the chip step for it. An empty cell
+is deliberate — better than a broken image or a logo composited off-style by
+hand.
+
 | File | Source |
 |---|---|
 | `claude_code.png` | <https://cdn.simpleicons.org/claude/_default> |
 | `claude_desktop.png` | <https://cdn.simpleicons.org/claude/_default> |
 | `openai_codex.png` | <https://svgl.app/library/openai.svg> |
 | `chatgpt_desktop.png` | <https://svgl.app/library/openai.svg> |
+| `grok_bot.png` | <https://cdn.simpleicons.org/grok/_default> — **not yet generated** |
 | `opencode.png` | <https://cdn.simpleicons.org/opencode/_default> |
 | `openclaw.png` | <https://svgl.app/library/openclaw.svg> |
 | `cursor.png` | <https://cdn.simpleicons.org/cursor/_default> |

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,7 +145,7 @@ surface --json --offline | jq '.usage.totals_by_tool'
 | **Binary** | ~2 MB, static, no runtime dependencies |
 | **Warm scan** | ~400 ms — 6 ms tools, 330 ms browser history, 50 ms transcripts |
 | **Cold scan** | ~19 s once, reading 900 MB of transcripts; ~50 ms thereafter |
-| **Coverage** | [18 AI tools · 30 AI domains · 10 browsers · 3 token sources](reference/coverage.md) |
+| **Coverage** | [19 AI tools · 30 AI domains · 10 browsers · 3 token sources](reference/coverage.md) |
 | **Platforms** | macOS, Linux, Windows — x86-64 and arm64 |
 | **Privilege** | Runs unprivileged. Never elevates, never prompts |
 | **Network** | One optional request, for model prices. `--offline` skips it |

--- a/docs/reference/coverage.md
+++ b/docs/reference/coverage.md
@@ -1,6 +1,6 @@
 # Coverage
 
-What surface knows how to recognise: **18 AI tools**, **30 AI domains**, **10
+What surface knows how to recognise: **19 AI tools**, **30 AI domains**, **10
 browsers** and **3 token sources**.
 
 Every table here is best-effort and expected to go stale — this space moves fast.
@@ -19,6 +19,7 @@ makes.
 | ![](../assets/tools/claude_desktop.png){ width="22" height="22" } | Claude Desktop | Anthropic | assistant | | `claude_desktop` |
 | ![](../assets/tools/openai_codex.png){ width="22" height="22" } | Codex CLI | OpenAI | coding agent | ✅ | `openai_codex` |
 | ![](../assets/tools/chatgpt_desktop.png){ width="22" height="22" } | ChatGPT Desktop | OpenAI | assistant | | `chatgpt_desktop` |
+|  | Grok Bot | xAI | autonomous agent | ✅ | `grok_bot` |
 | ![](../assets/tools/opencode.png){ width="22" height="22" } | OpenCode | SST | coding agent | ✅ | `opencode` |
 | ![](../assets/tools/openclaw.png){ width="22" height="22" } | OpenClaw | OpenClaw | autonomous agent | ✅ | `openclaw` |
 | ![](../assets/tools/cursor.png){ width="22" height="22" } | Cursor | Anysphere | editor | ✅ | `cursor` |
@@ -47,6 +48,7 @@ tool it is inventorying. Every detection carries its evidence into the
 | Claude Desktop | | | Claude | `Claude Helper` |
 | Codex CLI | `codex` | `~/.codex` | | `codex` |
 | ChatGPT Desktop | | | ChatGPT | `ChatGPT` |
+| Grok Bot | `Grok Bot` | `~/.grokbot` | Grok Bot | `Grok Bot` |
 | OpenCode | `opencode` | `~/.opencode`, `~/.config/opencode` | | `opencode` |
 | OpenClaw | `openclaw`, `clawdbot`, `moltbot` | `~/.openclaw`, `~/.clawdbot`, `~/.moltbot`, `~/.config/openclaw` | OpenClaw | `openclaw`, `clawdbot`, `moltbot` |
 | Cursor | `cursor` | `~/.cursor` | Cursor | `Cursor` |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -11,7 +11,7 @@ Every flag, every exit code, every environment variable.
 
 <div class="site-card" markdown>
 ### [Coverage](coverage.md)
-The 18 tools, 30 domains, 10 browsers and 3 token sources surface knows about.
+The 19 tools, 30 domains, 10 browsers and 3 token sources surface knows about.
 </div>
 
 <div class="site-card" markdown>

--- a/src/scan/tooling.rs
+++ b/src/scan/tooling.rs
@@ -130,6 +130,20 @@ pub const AI_TOOLS: &[AiTool] = &[
         extensions: &[],
     },
     AiTool {
+        id: "grok_bot",
+        name: "Grok Bot",
+        vendor: "xAI",
+        // Not an assistant: it ships a local-exec daemon, speaks MCP and can
+        // hold an egress tunnel open, so it runs unattended between prompts.
+        kind: ToolKind::AutonomousAgent,
+        autonomous: true,
+        apps: &["Grok Bot"],
+        executables: &["Grok Bot"],
+        config_paths: &[".grokbot"],
+        processes: &["Grok Bot"],
+        extensions: &[],
+    },
+    AiTool {
         id: "opencode",
         name: "OpenCode",
         vendor: "SST",
@@ -442,17 +456,37 @@ pub struct Summary {
 
 /// Application names need an exact match: `Claude` must not claim
 /// `Claude Code URL Handler`, which belongs to a different entry in the table.
-/// Windows DisplayNames carry suffixes like `Cursor (User)`, so a parenthesised
-/// or dashed qualifier is allowed.
+/// Windows DisplayNames carry suffixes like `Cursor (User)` or a bare version
+/// (`Grok Bot 0.44.0`), so a parenthesised, dashed, or version qualifier is
+/// allowed.
 fn matches_app(observed: &str, pattern: &str) -> bool {
     let observed = observed.trim();
     if observed.eq_ignore_ascii_case(pattern) {
         return true;
     }
-    observed
+    let Some(rest) = observed
         .get(..pattern.len())
-        .is_some_and(|head| head.eq_ignore_ascii_case(pattern))
-        && matches!(&observed[pattern.len()..], rest if rest.starts_with(" (") || rest.starts_with(" - "))
+        .filter(|head| head.eq_ignore_ascii_case(pattern))
+        .map(|_| &observed[pattern.len()..])
+    else {
+        return false;
+    };
+    rest.starts_with(" (") || rest.starts_with(" - ") || is_version_suffix(rest)
+}
+
+/// ` 0.44.0` yes, ` 3 Desktop` no.
+///
+/// Digits and dots only, to the end of the string: a version is the whole
+/// remainder or it is part of a different product's name. Without that anchor
+/// `Claude` would claim a hypothetical `Claude 3 Desktop`, which is exactly the
+/// over-reach the exact match above exists to prevent.
+fn is_version_suffix(rest: &str) -> bool {
+    let Some(digits) = rest.strip_prefix(' ') else {
+        return false;
+    };
+    !digits.is_empty()
+        && digits.starts_with(|c: char| c.is_ascii_digit())
+        && digits.chars().all(|c| c.is_ascii_digit() || c == '.')
 }
 
 /// Executables match exactly, after stripping a Windows extension.
@@ -724,6 +758,45 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(detected_ids(&match_tools(&observed)), vec!["cursor"]);
+    }
+
+    #[test]
+    fn a_versioned_display_name_still_matches() {
+        // Grok Bot registers as `Grok Bot 0.44.0`, and an installed copy that
+        // has never been launched has no config dir and no running process —
+        // the DisplayName is the only channel left.
+        let observed = Observed {
+            apps: vec!["Grok Bot 0.44.0".into()],
+            ..Default::default()
+        };
+        assert_eq!(detected_ids(&match_tools(&observed)), vec!["grok_bot"]);
+    }
+
+    #[test]
+    fn a_version_suffix_does_not_swallow_another_products_name() {
+        // ` 3 Desktop` is not a version, so `Claude` must not claim it.
+        let observed = Observed {
+            apps: vec!["Claude 3 Desktop".into()],
+            ..Default::default()
+        };
+        assert!(detected_ids(&match_tools(&observed)).is_empty());
+    }
+
+    #[test]
+    fn grok_bot_is_detected_and_counted_autonomous() {
+        // The config dir alone is enough; the daemon beside it is why this
+        // counts as an agent rather than a chat window.
+        let observed = Observed {
+            config_paths: vec![".grokbot".into()],
+            ..Default::default()
+        };
+        let detected = match_tools(&observed);
+        assert_eq!(detected_ids(&detected), vec!["grok_bot"]);
+
+        let tool = detected[0].tool;
+        assert!(tool.autonomous, "it executes locally between prompts");
+        assert_eq!(tool.vendor, "xAI");
+        assert_eq!(summarise(&detected).autonomous, 1);
     }
 
     #[test]


### PR DESCRIPTION
## What

xAI's Grok Bot desktop agent joins the tool table, taking the count from 18 to 19.

```
grok_bot   xAI   autonomous_agent   autonomous=true
evidence:  app:Grok Bot 0.44.0 · config:~/.grokbot · process:Grok Bot.exe
```

## Why autonomous, not assistant

On the evidence it leaves, not on the category its marketing uses. `~/.grokbot` holds `local-exec-daemon.json`, its credential and connection files, and `local-exec-supervisor.json`; `settings.json` carries `mcpBoxServers`, `localToolPermission` and `egressTunnelEnabled`. That is something which executes on this machine between prompts, so it counts toward the autonomous total on the Overview — the one judgement this tool makes.

## Detection only

`~/.grokbot` is 43 KB of daemon state and settings with no transcripts, and nothing in `AppData/Roaming/Grok Bot` is a readable usage record. So Grok Bot contributes **no tokens and no cost rows** — the same shape as Claude Desktop and ChatGPT Desktop already have in this table. It appears in the Tools view and the TOOLS & SITES count. `grok.com` and `x.ai` were already covered as domains.

## The app-matching change

Windows registers the DisplayName `Grok Bot 0.44.0`. `matches_app` allowed only ` (` and ` - ` qualifiers, so that channel missed it — and that channel is the only one that can see a GUI tool installed but never launched: no config directory yet, no process, nothing on `PATH`.

A trailing version is now accepted, anchored to digits and dots through end of string. ` 0.44.0` matches; ` 3 Desktop` does not, so `Claude` still cannot claim a hypothetical `Claude 3 Desktop`. There's a test for each direction.

## Verification

287 tests pass; `cargo fmt --check` and `cargo clippy --all-targets` clean. Four new tests: the versioned DisplayName, the near-miss it must not swallow, and detection plus the autonomous count from the config path alone.

Confirmed against a real installation — detected via all three channels, with tools going 3 → 4, autonomous 2 → 3, and xAI added to the vendor set.

## Needs a human

**The logo is not drawn.** `SOURCES.md` lists `grok_bot.png` with its source URL, but the 44px chip is composited by a script that lives in the PR that added the icons, not in this repo. Rather than commit a broken image link or hand-composite something off-style, the icon cell is empty in both tool tables. Someone with the chip step should run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
